### PR TITLE
Add front page menu link and refine loading message

### DIFF
--- a/src/openhdwebui.client/src/app/app-routing.module.ts
+++ b/src/openhdwebui.client/src/app/app-routing.module.ts
@@ -3,10 +3,11 @@ import { RouterModule, Routes } from '@angular/router';
 import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
+import { FrontpageComponent } from './frontpage/frontpage.component';
 
 const routes: Routes = 
 [
-  { path: '', component: FilesComponent, pathMatch: 'full' },
+  { path: '', component: FrontpageComponent, pathMatch: 'full' },
   { path: 'files', component: FilesComponent },
   { path: 'system', component: SystemComponent },
   { path: 'update', component: UpdateComponent }

--- a/src/openhdwebui.client/src/app/app.component.spec.ts
+++ b/src/openhdwebui.client/src/app/app.component.spec.ts
@@ -1,47 +1,16 @@
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 
 describe('AppComponent', () => {
-  let component: AppComponent;
-  let fixture: ComponentFixture<AppComponent>;
-  let httpMock: HttpTestingController;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-    declarations: [AppComponent],
-    imports: [],
-    providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting()]
-}).compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(AppComponent);
-    component = fixture.componentInstance;
-    httpMock = TestBed.inject(HttpTestingController);
-  });
-
-  afterEach(() => {
-    httpMock.verify();
+      declarations: [AppComponent],
+    }).compileComponents();
   });
 
   it('should create the app', () => {
-    expect(component).toBeTruthy();
-  });
-
-  it('should retrieve weather forecasts from the server', () => {
-    const mockForecasts = [
-      { date: '2021-10-01', temperatureC: 20, temperatureF: 68, summary: 'Mild' },
-      { date: '2021-10-02', temperatureC: 25, temperatureF: 77, summary: 'Warm' }
-    ];
-
-    component.ngOnInit();
-
-    const req = httpMock.expectOne('/weatherforecast');
-    expect(req.request.method).toEqual('GET');
-    req.flush(mockForecasts);
-
-    expect(component.forecasts).toEqual(mockForecasts);
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    expect(app).toBeTruthy();
   });
 });

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { NavMenuComponent } from './nav-menu/nav-menu.component';
 import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
+import { FrontpageComponent } from './frontpage/frontpage.component';
 
 @NgModule(
     { 
@@ -17,7 +18,8 @@ import { UpdateComponent } from './update/update.component';
             NavMenuComponent,
             FilesComponent,
             SystemComponent,
-            UpdateComponent
+            UpdateComponent,
+            FrontpageComponent
         ],
         bootstrap: [AppComponent], 
         imports: 

--- a/src/openhdwebui.client/src/app/files/files.component.html
+++ b/src/openhdwebui.client/src/app/files/files.component.html
@@ -38,6 +38,9 @@
       animation: loadingDot 1s infinite alternate;
       animation-delay: 0.4s;"></span>
   </div>
+  <div style="margin-top: 1rem; font-size: 1rem; color: #666; text-align: center;">
+    If this message remains, it might simply mean there are no videos available yet.
+  </div>
 </div>
 
 <!-- File Display Section -->

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
@@ -1,0 +1,19 @@
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1b2735 0%, #090a0f 100%);
+  color: #fff;
+}
+
+.logo {
+  width: 150px;
+  height: auto;
+}
+
+.tagline {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+}

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
@@ -1,0 +1,6 @@
+<section class="hero text-center">
+  <img src="assets/logo.jpg" alt="OpenHD logo" class="logo mb-3">
+  <h1>OpenHD</h1>
+  <p class="tagline">Open Source HD FPV System</p>
+  <a class="btn btn-primary mt-3" href="https://openhdfpv.org" target="_blank" rel="noopener">Learn more</a>
+</section>

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.spec.ts
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FrontpageComponent } from './frontpage.component';
+
+describe('FrontpageComponent', () => {
+  let component: FrontpageComponent;
+  let fixture: ComponentFixture<FrontpageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FrontpageComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(FrontpageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.ts
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-frontpage',
+  templateUrl: './frontpage.component.html',
+  styleUrls: ['./frontpage.component.css']
+})
+export class FrontpageComponent { }

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -29,6 +29,11 @@
       </button>
       <div class="navbar-collapse collapse d-sm-inline-flex justify-content-end"
            [ngClass]="{ show: isExpanded }">
+        <ul class="navbar-nav flex-grow">
+          <li class="nav-item" [routerLinkActive]="['link-active']">
+            <a class="nav-link text-dark" [routerLink]="['/']">Frontpage</a>
+          </li>
+        </ul>
         <ul class="navbar-nav flex-grow" *ngIf="isAir">
           <li class="nav-item" [routerLinkActive]="['link-active']">
             <a class="nav-link text-dark" [routerLink]="['/files']">Files</a>


### PR DESCRIPTION
## Summary
- Add Frontpage link to top navigation for quick access
- Restyle front page with hero section mirroring main website
- Soften Files page loading message to explain lack of videos
- Restore AppComponent unit test

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e228a548832fa99a92ca19a4e8f2