### PR TITLE
feat: add settings page and theme toggle

### DIFF
--- a/src/openhdwebui.client/src/app/app-routing.module.ts
+++ b/src/openhdwebui.client/src/app/app-routing.module.ts
@@ -4,13 +4,15 @@ import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
 import { FrontpageComponent } from './frontpage/frontpage.component';
+import { SettingsComponent } from './settings/settings.component';
 
 const routes: Routes = 
 [
   { path: '', component: FrontpageComponent, pathMatch: 'full' },
   { path: 'files', component: FilesComponent },
   { path: 'system', component: SystemComponent },
-  { path: 'update', component: UpdateComponent }
+  { path: 'update', component: UpdateComponent },
+  { path: 'settings', component: SettingsComponent }
 ];
 
 @NgModule({

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
 import { FrontpageComponent } from './frontpage/frontpage.component';
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule(
     { 
@@ -19,7 +20,8 @@ import { FrontpageComponent } from './frontpage/frontpage.component';
             FilesComponent,
             SystemComponent,
             UpdateComponent,
-            FrontpageComponent
+            FrontpageComponent,
+            SettingsComponent
         ],
         bootstrap: [AppComponent], 
         imports: 

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
@@ -4,8 +4,8 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background: linear-gradient(135deg, #1b2735 0%, #090a0f 100%);
-  color: #fff;
+  background: var(--background-gradient);
+  color: var(--text-color);
 }
 
 .logo {

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
@@ -1,5 +1,5 @@
 <section class="hero text-center">
-  <img src="assets/logo.jpg" alt="OpenHD logo" class="logo mb-3">
+  <img src="assets/logo.svg" alt="OpenHD logo" class="logo mb-3">
   <h1>OpenHD</h1>
   <p class="tagline">Open Source HD FPV System</p>
   <a class="btn btn-primary mt-3" href="https://openhdfpv.org" target="_blank" rel="noopener">Learn more</a>

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -1,16 +1,17 @@
 <header>
-  <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+  <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3"
+       [ngClass]="isDarkTheme ? 'navbar-dark bg-dark' : 'navbar-light bg-white'">
     <div class="container">
         <div class="row navbar-brand" >
             <div class="col">
-              <div class="row">
-                <a [routerLink]="['/']">
-                  <img src="assets/logo.jpg" height="40" class="d-inline-block align-top" alt="">
-                </a>
-              </div>
+                <div class="row">
+                  <a [routerLink]="['/']">
+                    <img src="assets/logo.svg" height="40" class="d-inline-block align-top" alt="OpenHD logo">
+                  </a>
+                </div>
             </div>
-            <div class="col">OpenHD WebUI</div>
-        </div>
+              <div class="col" [ngClass]="isDarkTheme ? 'text-light' : 'text-dark'">OpenHD WebUI</div>
+          </div>
 
       <button
         class="navbar-toggler"
@@ -24,32 +25,35 @@
       </button>
       <div class="navbar-collapse collapse d-sm-inline-flex justify-content-end"
            [ngClass]="{ show: isExpanded }">
+          <ul class="navbar-nav flex-grow">
+            <li class="nav-item" [routerLinkActive]="['link-active']">
+              <a class="nav-link" [routerLink]="['/']">Home</a>
+            </li>
+          </ul>
+          <ul class="navbar-nav flex-grow" *ngIf="isAir">
+            <li class="nav-item" [routerLinkActive]="['link-active']">
+              <a class="nav-link" [routerLink]="['/files']">Videos</a>
+            </li>
+          </ul>
+          <ul class="navbar-nav flex-grow">
+            <li class="nav-item" [routerLinkActive]="['link-active']">
+              <a class="nav-link" [routerLink]="['/settings']">Settings</a>
+            </li>
+          </ul>
+          <ul class="navbar-nav flex-grow">
+            <li class="nav-item" [routerLinkActive]="['link-active']">
+              <a class="nav-link" [routerLink]="['/system']">Debug</a>
+            </li>
+          </ul>
         <ul class="navbar-nav flex-grow">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/']">Home</a>
+            <a class="nav-link" [routerLink]="['/update']">Update</a>
           </li>
         </ul>
-        <ul class="navbar-nav flex-grow" *ngIf="isAir">
-          <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/files']">Videos</a>
-          </li>
-        </ul>
-        <ul class="navbar-nav flex-grow">
-          <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/settings']">Settings</a>
-          </li>
-        </ul>
-        <ul class="navbar-nav flex-grow">
-          <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/system']">Debug</a>
-          </li>
-        </ul>
-        <ul class="navbar-nav flex-grow">
-          <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/update']">Update</a>
-          </li>
-        </ul>
+        <button class="btn btn-sm btn-outline-secondary ms-3" (click)="toggleTheme()">
+          {{ isDarkTheme ? 'Light' : 'Dark' }} Mode
+        </button>
+        </div>
       </div>
-    </div>
-  </nav>
-</header>
+    </nav>
+  </header>

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.ts
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.ts
@@ -11,6 +11,7 @@ export class NavMenuComponent {
   isAir = false;
   isGround = false;
   version = "";
+  isDarkTheme = false;
 
   constructor(
     http: HttpClient) {
@@ -41,6 +42,15 @@ export class NavMenuComponent {
 
   toggle() {
     this.isExpanded = !this.isExpanded;
+  }
+
+  toggleTheme() {
+    this.isDarkTheme = !this.isDarkTheme;
+    if (this.isDarkTheme) {
+      document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+    }
   }
 }
 

--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -1,0 +1,1 @@
+/* Placeholder styles for settings component */

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -1,0 +1,20 @@
+<div class="container mt-4">
+  <h2>Settings</h2>
+
+  <div class="form-check form-switch my-3">
+    <input class="form-check-input" type="checkbox" id="dummySwitch">
+    <label class="form-check-label" for="dummySwitch">Enable feature</label>
+  </div>
+
+  <div class="my-3">
+    <label for="dummyRange" class="form-label">Adjust value</label>
+    <input type="range" class="form-range" id="dummyRange">
+  </div>
+
+  <div class="mb-3">
+    <label for="dummyText" class="form-label">Text field</label>
+    <input type="text" class="form-control" id="dummyText" placeholder="Enter text">
+  </div>
+
+  <p>Additional settings description text goes here.</p>
+</div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SettingsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.css']
+})
+export class SettingsComponent {
+}

--- a/src/openhdwebui.client/src/assets/logo.svg
+++ b/src/openhdwebui.client/src/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <rect width="200" height="60" fill="transparent" />
+  <text x="10" y="45" font-family="Arial, Helvetica, sans-serif" font-size="40" fill="#ff8c00">OpenHD</text>
+</svg>

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -1,18 +1,37 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+  --primary-color: #ff8c00;
+  --background-color: #f8f9fa;
+  --text-color: #212529;
+  --link-color: #ff8c00;
+  --background-gradient: linear-gradient(135deg, #ffffff 0%, #e6e6e6 100%);
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+}
+
 a {
-    color: #0366d6;
-  }
-  
-  .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-    box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
-  }
-  
-  code {
-    color: #e01a76;
-  }
-  
-  .btn-primary {
-    color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
-  }
+  color: var(--link-color);
+}
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--primary-color);
+}
+
+code {
+  color: #e01a76;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+body.dark-theme {
+  --background-color: #1b1f23;
+  --text-color: #f8f9fa;
+  --background-gradient: linear-gradient(135deg, #1b2735 0%, #090a0f 100%);
+}
+


### PR DESCRIPTION
## Summary
- align styling with OpenHD website colors
- add dark/light theme toggle and logo usage
- scaffold settings page with basic controls

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6f33edb4c832fb7498b847525af5d