### PR TITLE
Add settings page with theme toggle and OpenHD branding

### DIFF
--- a/src/openhdwebui.client/src/app/app-routing.module.ts
+++ b/src/openhdwebui.client/src/app/app-routing.module.ts
@@ -4,11 +4,13 @@ import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
 import { FrontpageComponent } from './frontpage/frontpage.component';
+import { SettingsComponent } from './settings/settings.component';
 
 const routes: Routes = 
 [
   { path: '', component: FrontpageComponent, pathMatch: 'full' },
   { path: 'files', component: FilesComponent },
+  { path: 'settings', component: SettingsComponent },
   { path: 'system', component: SystemComponent },
   { path: 'update', component: UpdateComponent }
 ];

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -9,27 +9,25 @@ import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
 import { FrontpageComponent } from './frontpage/frontpage.component';
+import { SettingsComponent } from './settings/settings.component';
 
-@NgModule(
-    { 
-        declarations: 
-        [
-            AppComponent,
-            NavMenuComponent,
-            FilesComponent,
-            SystemComponent,
-            UpdateComponent,
-            FrontpageComponent
-        ],
-        bootstrap: [AppComponent], 
-        imports: 
-        [
-            BrowserModule,
-            AppRoutingModule
-        ], 
-        providers: 
-            [
-                provideHttpClient(withInterceptorsFromDi())
-            ] 
-    })
+@NgModule({
+    declarations: [
+        AppComponent,
+        NavMenuComponent,
+        FilesComponent,
+        SystemComponent,
+        UpdateComponent,
+        FrontpageComponent,
+        SettingsComponent
+    ],
+    bootstrap: [AppComponent],
+    imports: [
+        BrowserModule,
+        AppRoutingModule
+    ],
+    providers: [
+        provideHttpClient(withInterceptorsFromDi())
+    ]
+})
 export class AppModule { }

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
@@ -4,8 +4,8 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background: linear-gradient(135deg, #1b2735 0%, #090a0f 100%);
-  color: #fff;
+  background: var(--hero-bg);
+  color: var(--text-color);
 }
 
 .logo {

--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.html
@@ -1,5 +1,6 @@
 <section class="hero text-center">
-  <img src="assets/logo.jpg" alt="OpenHD logo" class="logo mb-3">
+  <img src="assets/logo-light.svg" alt="OpenHD logo" class="logo logo-light mb-3">
+  <img src="assets/logo-dark.svg" alt="OpenHD logo" class="logo logo-dark mb-3">
   <h1>OpenHD</h1>
   <p class="tagline">Open Source HD FPV System</p>
   <a class="btn btn-primary mt-3" href="https://openhdfpv.org" target="_blank" rel="noopener">Learn more</a>

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -1,11 +1,12 @@
 <header>
-  <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+  <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
     <div class="container">
         <div class="row navbar-brand" >
             <div class="col">
               <div class="row">
                 <a [routerLink]="['/']">
-                  <img src="assets/logo.jpg" height="40" class="d-inline-block align-top" alt="">
+                  <img src="assets/logo-light.svg" height="40" class="d-inline-block align-top logo-light" alt="OpenHD logo">
+                  <img src="assets/logo-dark.svg" height="40" class="d-inline-block align-top logo-dark" alt="OpenHD logo">
                 </a>
               </div>
             </div>
@@ -26,27 +27,27 @@
            [ngClass]="{ show: isExpanded }">
         <ul class="navbar-nav flex-grow">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/']">Home</a>
+            <a class="nav-link" [routerLink]="['/']">Home</a>
           </li>
         </ul>
         <ul class="navbar-nav flex-grow" *ngIf="isAir">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/files']">Videos</a>
+            <a class="nav-link" [routerLink]="['/files']">Videos</a>
           </li>
         </ul>
         <ul class="navbar-nav flex-grow">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/settings']">Settings</a>
+            <a class="nav-link" [routerLink]="['/settings']">Settings</a>
           </li>
         </ul>
         <ul class="navbar-nav flex-grow">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/system']">Debug</a>
+            <a class="nav-link" [routerLink]="['/system']">Debug</a>
           </li>
         </ul>
         <ul class="navbar-nav flex-grow">
           <li class="nav-item" [routerLinkActive]="['link-active']">
-            <a class="nav-link text-dark" [routerLink]="['/update']">Update</a>
+            <a class="nav-link" [routerLink]="['/update']">Update</a>
           </li>
         </ul>
       </div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -1,0 +1,8 @@
+.settings {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -1,0 +1,25 @@
+<div class="settings">
+  <h2>Settings</h2>
+  <div class="form-group">
+    <label>
+      <input type="checkbox" (change)="onThemeToggle()" [checked]="themeService.isDark">
+      Dark mode
+    </label>
+  </div>
+  <div class="form-group">
+    <label>
+      <input type="checkbox"> Dummy switch
+    </label>
+  </div>
+  <div class="form-group">
+    <label>Dummy slider
+      <input type="range" min="0" max="100">
+    </label>
+  </div>
+  <div class="form-group">
+    <label>Dummy text
+      <input type="text" placeholder="Enter text">
+    </label>
+  </div>
+  <p>These settings are placeholders for future configuration.</p>
+</div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SettingsComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { ThemeService } from '../theme.service';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.css']
+})
+export class SettingsComponent {
+  constructor(public themeService: ThemeService) {}
+
+  onThemeToggle(): void {
+    this.themeService.toggle();
+  }
+}

--- a/src/openhdwebui.client/src/app/theme.service.ts
+++ b/src/openhdwebui.client/src/app/theme.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  isDark = false;
+
+  toggle(): void {
+    this.isDark = !this.isDark;
+    const body = document.body;
+    if (this.isDark) {
+      body.classList.add('dark-theme');
+    } else {
+      body.classList.remove('dark-theme');
+    }
+  }
+}

--- a/src/openhdwebui.client/src/assets/logo-dark.svg
+++ b/src/openhdwebui.client/src/assets/logo-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50">
+  <text x="0" y="35" font-family="Arial, sans-serif" font-size="35" fill="#ffffff">Open</text>
+  <text x="110" y="35" font-family="Arial, sans-serif" font-size="35" fill="#d62828">HD</text>
+</svg>

--- a/src/openhdwebui.client/src/assets/logo-light.svg
+++ b/src/openhdwebui.client/src/assets/logo-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 50">
+  <text x="0" y="35" font-family="Arial, sans-serif" font-size="35" fill="#000000">Open</text>
+  <text x="110" y="35" font-family="Arial, sans-serif" font-size="35" fill="#d62828">HD</text>
+</svg>

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -1,18 +1,62 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global theme variables and styles */
+
+:root {
+  --primary-color: #d62828;
+  --background-color: #ffffff;
+  --text-color: #212529;
+  --link-color: var(--primary-color);
+  --hero-bg: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+}
+
+body {
+  background-color: var(--background-color);
+  color: var(--text-color);
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
 a {
-    color: #0366d6;
-  }
-  
-  .btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-    box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
-  }
-  
-  code {
-    color: #e01a76;
-  }
-  
-  .btn-primary {
-    color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
-  }
+  color: var(--link-color);
+}
+
+nav a.nav-link {
+  color: var(--text-color);
+}
+
+nav.navbar {
+  background-color: var(--background-color);
+}
+
+
+.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
+  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem var(--primary-color);
+}
+
+code {
+  color: #e01a76;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.dark-theme {
+  --background-color: #121212;
+  --text-color: #f8f9fa;
+  --hero-bg: linear-gradient(135deg, #d62828 0%, #000000 100%);
+}
+
+.logo-dark {
+  display: none;
+}
+
+.dark-theme .logo-light {
+  display: none;
+}
+
+.dark-theme .logo-dark {
+  display: inline;
+}
+


### PR DESCRIPTION
## Summary
- Align styling with OpenHD colors and add dark/light theme toggle
- Introduce settings page containing placeholder controls
- Display OpenHD logos on front page and navigation bar

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6f33edb4c832fb7498b847525af5d