### PR TITLE
Add dark mode toggle and center page content

### DIFF
--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.css
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.css
@@ -1,8 +1,8 @@
-a.navbar-brand {
+.navbar-brand {
   white-space: normal;
   text-align: center;
   word-break: break-all;
-  color:#fff;
+  color: var(--primary-color);
 }
 
 html {

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -1,16 +1,15 @@
 <header>
   <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
-    <div class="container">
-        <div class="row navbar-brand" >
-            <div class="col">
-              <div class="row">
-                <a [routerLink]="['/']">
-                  <img src="assets/OpenHD-Logo.png" height="40" class="d-inline-block align-top logo-dark" alt="OpenHD logo">
-                </a>
-              </div>
-            </div>
-            <div class="col">OpenHD WebUI</div>
-        </div>
+    <div class="container d-flex align-items-center">
+      <label class="form-check form-switch mb-0 me-3">
+        <input class="form-check-input" type="checkbox" (change)="themeService.toggle()" [checked]="themeService.isDark">
+      </label>
+      <div class="navbar-brand d-flex align-items-center me-auto">
+        <a [routerLink]="['/']">
+          <img src="assets/OpenHD-Logo.png" height="40" class="d-inline-block align-top logo-dark" alt="OpenHD logo">
+        </a>
+        <span class="ms-2">OpenHD WebUI</span>
+      </div>
 
       <button
         class="navbar-toggler"

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.ts
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { HttpClient } from "@angular/common/http";
+import { ThemeService } from '../theme.service';
 
 @Component({
   selector: 'app-nav-menu',
@@ -13,7 +14,8 @@ export class NavMenuComponent {
   version = "";
 
   constructor(
-    http: HttpClient) {
+    http: HttpClient,
+    public themeService: ThemeService) {
     http.get<IAirGroundStatus>('/api/info/ag-state')
       .subscribe({
         next: obj => {

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -45,6 +45,7 @@ code {
 .dark-theme {
   --background-color: #1c262f;
   --text-color: #f8f9fa;
+  --primary-color: #ffffff;
   --hero-bg: linear-gradient(135deg, #000000 0%, #000000 100%);
 }
 
@@ -58,5 +59,11 @@ code {
 
 .dark-theme .logo-dark {
   display: inline;
+}
+
+main.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- Show dark mode switch on the left side of the top navigation bar
- Use theme primary color for brand and switch it to white in dark mode
- Center main page content with flex layout

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a83be40fa4832fa3202ea40aea1419