### PR TITLE
Default to dark theme and expand layout width

### DIFF
--- a/src/openhdwebui.client/src/app/app.component.html
+++ b/src/openhdwebui.client/src/app/app.component.html
@@ -1,6 +1,6 @@
 ﻿<body>
     <app-nav-menu></app-nav-menu>
-    <main class="container">
+    <main class="container-fluid">
       <router-outlet></router-outlet>
     </main>
   </body>

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -1,6 +1,6 @@
 <header>
   <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
-    <div class="container d-flex align-items-center">
+    <div class="container-fluid d-flex align-items-center">
 
       <div class="navbar-brand d-flex align-items-center me-auto">
         <a [routerLink]="['/']">

--- a/src/openhdwebui.client/src/app/theme.service.ts
+++ b/src/openhdwebui.client/src/app/theme.service.ts
@@ -4,7 +4,11 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class ThemeService {
-  isDark = false;
+  isDark = true;
+
+  constructor() {
+    document.body.classList.add('dark-theme');
+  }
 
   toggle(): void {
     this.isDark = !this.isDark;

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -61,7 +61,7 @@ code {
   display: inline;
 }
 
-main.container {
+main {
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- enable dark mode on initial load
- stretch layout to full width while maintaining centered content

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a89b31d688832f94bc9925c6da92f2