### PR TITLE
feat: use theme-aware text colors

### DIFF
--- a/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
+++ b/src/openhdwebui.client/src/app/frontpage/frontpage.component.css
@@ -2,7 +2,7 @@
   --bg: #0a0f1a;
   --surface: rgba(255,255,255,.05);
   --surface-strong: rgba(255,255,255,.08);
-  --text: #e6e9ef;
+  --text: #fff;
   --muted: #9aa3b2;
   --accent: #3cc7ff; /* single accent */
   --shadow: 0 10px 30px rgba(0,0,0,.35);
@@ -13,7 +13,7 @@
     --bg: #f7f9fc;
     --surface: rgba(0,0,0,.04);
     --surface-strong: rgba(0,0,0,.06);
-    --text: #0b1220;
+    --text: #000;
     --muted: #596273;
   }
 }
@@ -30,11 +30,11 @@ html, body { background: var(--bg); color: var(--text); }
 .mb-4 { margin-bottom: 1.5rem; }
 .mb-5 {
    margin-bottom: 3rem;
-   color: #fff; 
+   color: var(--text);
   }
 .w-100 { width: 100%; }
 .h3 {
-  color: #fff;
+  color: var(--text);
 }
 
 .topbar {
@@ -55,7 +55,7 @@ html, body { background: var(--bg); color: var(--text); }
   border: 1px solid transparent; border-radius: .75rem; padding: .6rem .95rem;
   font-weight: 600; cursor: pointer; transition: transform .15s ease, box-shadow .15s ease, background .2s ease, border-color .2s ease;
 }
-.btn--accent { background: linear-gradient(135deg, var(--accent), #7af0ff); color: #061018; box-shadow: 0 6px 20px rgba(60,199,255,.35); }
+.btn--accent { background: linear-gradient(135deg, var(--accent), #7af0ff); color: var(--text); box-shadow: 0 6px 20px rgba(60,199,255,.35); }
 .btn--accent:hover { transform: translateY(-1px); }
 .btn--ghost { background: transparent; border-color: var(--surface-strong); color: var(--text); }
 .btn--ghost:hover { background: var(--surface); }
@@ -69,7 +69,6 @@ html, body { background: var(--bg); color: var(--text); }
 
 .section-label {
   display: inline-block; color: var(--accent); letter-spacing: .12rem; font-size: .85rem;
-  color: #00a6f2;
   border-left: 3px solid var(--accent); padding-left: .6rem;
 }
 

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -3,7 +3,7 @@
 :root {
   --primary-color: #00a6f2;
   --background-color: #ffffff;
-  --text-color: #212d37;
+  --text-color: #000;
   --link-color: var(--primary-color);
   --hero-bg: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
   --nav-background-color: var(--background-color);
@@ -46,14 +46,14 @@ code {
 }
 
 .btn-primary {
-  color: #fff;
+  color: var(--text-color);
   background-color: var(--primary-color);
   border-color: var(--primary-color);
 }
 
 .dark-theme {
   --background-color: #212d37;
-  --text-color: #f8f9fa;
+  --text-color: #fff;
   --primary-color: #ffffff;
   --hero-bg: #1c262f;
   --nav-background-color: #1c262f;


### PR DESCRIPTION
## Summary
- define theme-based text variables and apply them to headings and paragraphs on the front page
- use shared text-color variable for primary buttons so text switches between dark and light modes

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build -- --configuration development`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb11d7c8832fb1b8774afdb9b006