### PR TITLE
feat: add terminal and material system page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
-*.sh text=auto eol=lf # linux line-endings
-postinst text=auto eol=lf   # linux line-endings
+*.sh text=auto eol=lf
+postinst text=auto eol=lf
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/src/OpenHdWebUi.Server/Controllers/SystemController.cs
+++ b/src/OpenHdWebUi.Server/Controllers/SystemController.cs
@@ -6,6 +6,7 @@ using OpenHdWebUi.Server.Configuration;
 using OpenHdWebUi.Server.Models;
 using OpenHdWebUi.Server.Services.Commands;
 using OpenHdWebUi.Server.Services.Files;
+using System.Diagnostics;
 
 namespace OpenHdWebUi.Server.Controllers;
 
@@ -59,6 +60,24 @@ public class SystemController : ControllerBase
         }
 
         return NoContent();
+    }
+
+    [HttpPost("run-terminal")]
+    public async Task<string> RunTerminal([FromBody] RunTerminalCommandRequest request)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            ArgumentList = { "-c", request.Command },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        using var process = Process.Start(psi);
+        var output = await process!.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+        return output + error;
     }
 }
 

--- a/src/OpenHdWebUi.Server/Models/Records.cs
+++ b/src/OpenHdWebUi.Server/Models/Records.cs
@@ -6,6 +6,8 @@ public record SystemFileDto(string Id, string DisplayName);
 
 public record RunCommandRequest(string Id);
 
+public record RunTerminalCommandRequest(string Command);
+
 public record ServerFileInfo(string FileName, string DownloadPath);
 
 public record AirGroundStatus(bool IsAir, bool IsGround);

--- a/src/openhdwebui.client/package.json
+++ b/src/openhdwebui.client/package.json
@@ -21,11 +21,15 @@
     "@angular/platform-browser": "^18.2.12",
     "@angular/platform-browser-dynamic": "^18.2.12",
     "@angular/router": "^18.2.12",
+    "@angular/cdk": "^18.2.12",
+    "@angular/material": "^18.2.12",
     "bootstrap": "^5.3.3",
     "jest-editor-support": "*",
     "run-script-os": "*",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
+    "xterm": "^5.3.0",
+    "xterm-addon-fit": "^0.8.0",
     "zone.js": "~0.14.2"
   },
   "devDependencies": {

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -1,7 +1,11 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -26,8 +30,12 @@ import { SettingsComponent } from './settings/settings.component';
     bootstrap: [AppComponent],
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
-        ReactiveFormsModule
+        ReactiveFormsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatListModule
     ],
     providers: [
         provideHttpClient(withInterceptorsFromDi())

--- a/src/openhdwebui.client/src/app/system/system.component.css
+++ b/src/openhdwebui.client/src/app/system/system.component.css
@@ -1,0 +1,31 @@
+@import 'xterm/css/xterm.css';
+
+.system-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.lists {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.list-card {
+  flex: 1 1 300px;
+}
+
+.terminal-card {
+  flex: 1 1 auto;
+  margin-top: 16px;
+  height: 60vh;
+}
+
+.terminal {
+  height: 100%;
+}
+

--- a/src/openhdwebui.client/src/app/system/system.component.html
+++ b/src/openhdwebui.client/src/app/system/system.component.html
@@ -1,30 +1,31 @@
-<div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
-    <div class="col">
-        <div class="card mb-4 rounded-3 shadow-sm">
-            <div class="card-header py-3">
-                <h4 class="my-0 fw-normal">System commands</h4>
-            </div>
-          <div class="card-body">
-              <ul class="list-unstyled mt-3 mb-4" *ngFor="let command of commands">
-                <li>
-                    <button type="button" (click)="onCommandClick(command)" class="w-100 btn btn-lg btn-outline-primary">{{command.displayName}}</button>
-                </li>
-              </ul>
-          </div>
-        </div>
-    </div>
-    <div class="col">
-        <div class="card mb-4 rounded-3 shadow-sm">
-            <div class="card-header py-3">
-                <h4 class="my-0 fw-normal">System files</h4>
-            </div>
-          <div class="card-body">
-            <ul class="list-unstyled mt-3 mb-4" *ngFor="let file of files">
-              <li>
-                  <a role="button" class="w-100 btn btn-lg btn-outline-primary" href="api/system/get-file/{{ file.id }}">{{file.displayName}}</a>
-              </li>
-            </ul>
-          </div>
-        </div>
-    </div>
+<div class="system-container">
+  <div class="lists">
+    <mat-card class="list-card">
+      <mat-card-title>System Commands</mat-card-title>
+      <mat-list>
+        <mat-list-item *ngFor="let command of commands">
+          <button mat-raised-button color="primary" (click)="onCommandClick(command)">
+            {{ command.displayName }}
+          </button>
+        </mat-list-item>
+      </mat-list>
+    </mat-card>
+
+    <mat-card class="list-card">
+      <mat-card-title>System Files</mat-card-title>
+      <mat-list>
+        <mat-list-item *ngFor="let file of files">
+          <a mat-raised-button color="primary" [href]="'api/system/get-file/' + file.id">
+            {{ file.displayName }}
+          </a>
+        </mat-list-item>
+      </mat-list>
+    </mat-card>
+  </div>
+
+  <mat-card class="terminal-card">
+    <mat-card-title>Terminal</mat-card-title>
+    <div #terminal class="terminal"></div>
+  </mat-card>
 </div>
+

--- a/src/openhdwebui.client/src/app/system/system.component.spec.ts
+++ b/src/openhdwebui.client/src/app/system/system.component.spec.ts
@@ -1,4 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
 
 import { SystemComponent } from './system.component';
 
@@ -8,9 +13,15 @@ describe('CommandsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [SystemComponent ]
-    })
-    .compileComponents();
+      declarations: [SystemComponent],
+      imports: [
+        HttpClientTestingModule,
+        BrowserAnimationsModule,
+        MatButtonModule,
+        MatCardModule,
+        MatListModule
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(SystemComponent);
     component = fixture.componentInstance;

--- a/src/openhdwebui.client/src/app/system/system.component.ts
+++ b/src/openhdwebui.client/src/app/system/system.component.ts
@@ -1,16 +1,23 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
 
 @Component({
   selector: 'app-system',
   templateUrl: './system.component.html',
   styleUrls: ['./system.component.css']
 })
-export class SystemComponent implements OnInit {
+export class SystemComponent implements OnInit, AfterViewInit {
   private httpClient: HttpClient;
 
   public commands: SystemCommandDto[] = [];
   public files: SystemFileDto[] = [];
+  private term: Terminal = new Terminal({ cols: 80, rows: 24 });
+  private fitAddon: FitAddon = new FitAddon();
+  private currentInput = '';
+
+  @ViewChild('terminal') terminalDiv!: ElementRef;
 
   constructor(http: HttpClient) {
     
@@ -25,6 +32,47 @@ export class SystemComponent implements OnInit {
   }
 
   ngOnInit(): void {
+  }
+
+  ngAfterViewInit(): void {
+    this.term.loadAddon(this.fitAddon);
+    this.term.open(this.terminalDiv.nativeElement);
+    this.fitAddon.fit();
+    this.prompt();
+
+    this.term.onData((data: string) => {
+      switch (data) {
+        case '\r':
+          const command = this.currentInput.trim();
+          this.currentInput = '';
+          this.httpClient.post('/api/system/run-terminal', { command }, { responseType: 'text' })
+            .subscribe(output => {
+              if (output) {
+                this.term.writeln(`\r\n${output}`);
+              }
+              this.prompt();
+            }, error => {
+              console.error(error);
+              this.prompt();
+            });
+          break;
+        case '\u007F':
+          if (this.currentInput.length > 0) {
+            this.currentInput = this.currentInput.slice(0, -1);
+            this.term.write('\b \b');
+          }
+          break;
+        default:
+          this.currentInput += data;
+          this.term.write(data);
+      }
+    });
+
+    window.addEventListener('resize', () => this.fitAddon.fit());
+  }
+
+  private prompt(): void {
+    this.term.write('\r\n$ ');
   }
 
   onCommandClick(command: SystemCommandDto): void {

--- a/src/openhdwebui.client/src/styles.css
+++ b/src/openhdwebui.client/src/styles.css
@@ -1,3 +1,5 @@
+@import 'xterm/css/xterm.css';
+
 /* Global theme variables and styles */
 
 :root {


### PR DESCRIPTION
## Summary
- revamp system page with Angular Material and responsive layout
- add xterm-based terminal and server endpoint to execute shell commands
- fix .gitattributes parsing

## Testing
- `dotnet build src/OpenHdWebUi.Server/OpenHdWebUi.Server.csproj` *(fails: command not found)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d2dd74e4832fa8e2e366ee42bab4