### PR TITLE
style: redesign system debug page

### DIFF
--- a/src/openhdwebui.client/src/app/system/system.component.css
+++ b/src/openhdwebui.client/src/app/system/system.component.css
@@ -1,0 +1,40 @@
+/* Dark themed container for the system debug page */
+:host {
+  display: block;
+  background-color: #1c252e;
+  color: #ffffff;
+  padding: 1rem;
+}
+
+.card {
+  background-color: #2a3440;
+  color: #ffffff;
+}
+
+.btn-outline-primary {
+  color: #ffffff;
+  border-color: #4b5563;
+}
+
+.btn-outline-primary:hover {
+  background-color: #4b5563;
+  color: #ffffff;
+}
+
+.terminal-wrapper {
+  background-color: #0d1117;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.terminal {
+  margin: 0;
+  white-space: pre-wrap;
+  color: #ffffff;
+  background-color: #0d1117;
+  width: 100%;
+  height: 200px;
+  overflow-y: auto;
+  font-family: monospace;
+}

--- a/src/openhdwebui.client/src/app/system/system.component.html
+++ b/src/openhdwebui.client/src/app/system/system.component.html
@@ -1,30 +1,37 @@
-<div class="row row-cols-1 row-cols-md-3 mb-3 text-center">
+<div class="system-container">
+  <div class="row row-cols-1 row-cols-md-2 mb-3 text-center">
     <div class="col">
-        <div class="card mb-4 rounded-3 shadow-sm">
-            <div class="card-header py-3">
-                <h4 class="my-0 fw-normal">System commands</h4>
-            </div>
-          <div class="card-body">
-              <ul class="list-unstyled mt-3 mb-4" *ngFor="let command of commands">
-                <li>
-                    <button type="button" (click)="onCommandClick(command)" class="w-100 btn btn-lg btn-outline-primary">{{command.displayName}}</button>
-                </li>
-              </ul>
-          </div>
+      <div class="card mb-4 rounded-3 shadow-sm">
+        <div class="card-header py-3">
+          <h4 class="my-0 fw-normal">System Commands</h4>
         </div>
+        <div class="card-body">
+          <ul class="list-unstyled mt-3 mb-4" *ngFor="let command of commands">
+            <li>
+              <button type="button" (click)="onCommandClick(command)" class="w-100 btn btn-lg btn-outline-primary">{{command.displayName}}</button>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
     <div class="col">
-        <div class="card mb-4 rounded-3 shadow-sm">
-            <div class="card-header py-3">
-                <h4 class="my-0 fw-normal">System files</h4>
-            </div>
-          <div class="card-body">
-            <ul class="list-unstyled mt-3 mb-4" *ngFor="let file of files">
-              <li>
-                  <a role="button" class="w-100 btn btn-lg btn-outline-primary" href="api/system/get-file/{{ file.id }}">{{file.displayName}}</a>
-              </li>
-            </ul>
-          </div>
+      <div class="card mb-4 rounded-3 shadow-sm">
+        <div class="card-header py-3">
+          <h4 class="my-0 fw-normal">System Files</h4>
         </div>
+        <div class="card-body">
+          <ul class="list-unstyled mt-3 mb-4" *ngFor="let file of files">
+            <li>
+              <a role="button" class="w-100 btn btn-lg btn-outline-primary" href="api/system/get-file/{{ file.id }}">{{file.displayName}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
+  </div>
+
+  <div class="terminal-wrapper" *ngIf="showTerminal">
+    <pre class="terminal">{{terminalText}}</pre>
+  </div>
+  <button class="btn btn-outline-light" (click)="toggleTerminal()">{{ showTerminal ? 'Hide Terminal' : 'Show Terminal' }}</button>
 </div>

--- a/src/openhdwebui.client/src/app/system/system.component.ts
+++ b/src/openhdwebui.client/src/app/system/system.component.ts
@@ -11,6 +11,8 @@ export class SystemComponent implements OnInit {
 
   public commands: SystemCommandDto[] = [];
   public files: SystemFileDto[] = [];
+  public showTerminal = true;
+  public terminalText = 'guest@5';
 
   constructor(http: HttpClient) {
     
@@ -33,6 +35,10 @@ export class SystemComponent implements OnInit {
 
   onFileClick(file: SystemFileDto): void {
     //this.httpClient.get(this.baseUrl + 'api/system/run-command', { id: command.id }).subscribe(result => { }, error => console.error(error));
+  }
+
+  toggleTerminal(): void {
+    this.showTerminal = !this.showTerminal;
   }
 
 }


### PR DESCRIPTION
## Summary
- Revamp system debug page to align with new design
- Add dark-themed cards for system commands and files
- Introduce toggleable terminal section for debugging

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c23a6264832f8b2cb91ecca65af0