### PR TITLE
Redesign system page layout

### DIFF
--- a/src/openhdwebui.client/src/app/system/system.component.css
+++ b/src/openhdwebui.client/src/app/system/system.component.css
@@ -3,34 +3,57 @@
 .system-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
-  width: 100%;
-  padding: 16px;
+  gap: 1rem;
+  padding: 1rem;
   box-sizing: border-box;
 }
 
 .lists {
   display: flex;
+  gap: 2rem;
   flex-wrap: wrap;
-  gap: 16px;
 }
 
-.list-card {
+.commands,
+.files {
   flex: 1 1 300px;
+  display: flex;
+  flex-direction: column;
 }
 
-.terminal-toggle {
-  margin-top: 16px;
-  align-self: flex-start;
+.commands h2,
+.files h2 {
+  margin-top: 0;
 }
 
-.terminal-card {
-  flex: 1 1 auto;
-  margin-top: 16px;
+.commands button,
+.files a {
+  display: block;
+  width: 100%;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: #2b3845;
+  color: var(--text-color);
+  border: none;
+  border-radius: 4px;
+  text-decoration: none;
+  text-align: left;
+}
+
+.commands button {
+  cursor: pointer;
+}
+
+.terminal-wrapper {
   height: 60vh;
 }
 
 .terminal {
   height: 100%;
+}
+
+.terminal-toggle {
+  align-self: center;
+  padding: 0.5rem 1.5rem;
 }
 

--- a/src/openhdwebui.client/src/app/system/system.component.html
+++ b/src/openhdwebui.client/src/app/system/system.component.html
@@ -1,35 +1,26 @@
 <div class="system-container">
   <div class="lists">
-    <mat-card class="list-card">
-      <mat-card-title>System Commands</mat-card-title>
-      <mat-list>
-        <mat-list-item *ngFor="let command of commands">
-          <button mat-raised-button color="primary" (click)="onCommandClick(command)">
-            {{ command.displayName }}
-          </button>
-        </mat-list-item>
-      </mat-list>
-    </mat-card>
+    <div class="commands">
+      <h2>System Commands</h2>
+      <button *ngFor="let command of commands" (click)="onCommandClick(command)">
+        {{ command.displayName }}
+      </button>
+    </div>
 
-  <mat-card class="list-card">
-      <mat-card-title>System Files</mat-card-title>
-      <mat-list>
-        <mat-list-item *ngFor="let file of files">
-          <a mat-raised-button color="primary" [href]="'api/system/get-file/' + file.id">
-            {{ file.displayName }}
-          </a>
-        </mat-list-item>
-      </mat-list>
-    </mat-card>
+    <div class="files">
+      <h2>System Files</h2>
+      <a *ngFor="let file of files" [href]="'api/system/get-file/' + file.id">
+        {{ file.displayName }}
+      </a>
+    </div>
   </div>
 
-  <button mat-raised-button color="primary" class="terminal-toggle" (click)="toggleTerminal()">
+  <div class="terminal-wrapper" [hidden]="!showTerminal">
+    <div #terminal class="terminal"></div>
+  </div>
+
+  <button class="terminal-toggle" (click)="toggleTerminal()">
     {{ showTerminal ? 'Hide Terminal' : 'Show Terminal' }}
   </button>
-
-  <mat-card class="terminal-card" [hidden]="!showTerminal">
-    <mat-card-title>Terminal</mat-card-title>
-    <div #terminal class="terminal"></div>
-  </mat-card>
 </div>
 

--- a/src/openhdwebui.client/src/app/system/system.component.ts
+++ b/src/openhdwebui.client/src/app/system/system.component.ts
@@ -13,7 +13,7 @@ export class SystemComponent implements OnInit, AfterViewInit {
 
   public commands: SystemCommandDto[] = [];
   public files: SystemFileDto[] = [];
-  public showTerminal = false;
+  public showTerminal = true;
   private term: Terminal = new Terminal({ cols: 80, rows: 24 });
   private fitAddon: FitAddon = new FitAddon();
   private currentInput = '';


### PR DESCRIPTION
## Summary
- Simplify system page HTML with custom layout for commands, files, and terminal
- Add new styling for side-by-side lists and centered terminal toggle
- Show terminal by default with updated visibility toggle logic

## Testing
- `npm ci` *(fails: 403 Forbidden fetching packages)*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cbe4b898832fa221ede866587763