### PR TITLE
feat(settings): add network interface management

### DIFF
--- a/src/OpenHdWebUi.Server/Controllers/NetworkController.cs
+++ b/src/OpenHdWebUi.Server/Controllers/NetworkController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenHdWebUi.Server.Models;
+using OpenHdWebUi.Server.Services.Network;
+using System.Threading.Tasks;
+
+namespace OpenHdWebUi.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class NetworkController : ControllerBase
+{
+    private readonly NetworkInfoService _service;
+
+    public NetworkController(NetworkInfoService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet("info")]
+    public NetworkInfoDto GetInfo()
+    {
+        return _service.GetNetworkInfo();
+    }
+
+    [HttpPost("ethernet")]
+    public async Task<IActionResult> SetEthernet([FromBody] SetIpRequest request)
+    {
+        await _service.SetEthernetIpAsync(request.Interface, request.Ip, request.Netmask);
+        return Ok();
+    }
+}

--- a/src/OpenHdWebUi.Server/Models/Records.cs
+++ b/src/OpenHdWebUi.Server/Models/Records.cs
@@ -13,3 +13,10 @@ public record ServerFileInfo(string FileName, string DownloadPath);
 public record AirGroundStatus(bool IsAir, bool IsGround);
 
 public record LoginRequest(string Username, string Password);
+public record WifiInterfaceDto(string Name, string Driver);
+
+public record EthernetInterfaceDto(string Name, string IpAddress, string Netmask);
+
+public record NetworkInfoDto(IReadOnlyCollection<WifiInterfaceDto> Wifi, IReadOnlyCollection<EthernetInterfaceDto> Ethernet);
+
+public record SetIpRequest(string Interface, string Ip, string Netmask);

--- a/src/OpenHdWebUi.Server/Program.cs
+++ b/src/OpenHdWebUi.Server/Program.cs
@@ -8,6 +8,7 @@ using OpenHdWebUi.Server.Services.AirGround;
 using OpenHdWebUi.Server.Services.Commands;
 using OpenHdWebUi.Server.Services.Files;
 using OpenHdWebUi.Server.Services.Media;
+using OpenHdWebUi.Server.Services.Network;
 
 namespace OpenHdWebUi.Server;
 
@@ -26,7 +27,8 @@ public class Program
             .Bind(builder.Configuration);
         builder.Services
             .AddScoped<SystemCommandsService>()
-            .AddScoped<SystemFilesService>();
+            .AddScoped<SystemFilesService>()
+            .AddScoped<NetworkInfoService>();
         builder.Services
             .AddSingleton<MediaService>()
             .AddSingleton<AirGroundService>();

--- a/src/OpenHdWebUi.Server/Services/Network/NetworkInfoService.cs
+++ b/src/OpenHdWebUi.Server/Services/Network/NetworkInfoService.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using OpenHdWebUi.Server.Models;
+
+namespace OpenHdWebUi.Server.Services.Network;
+
+public class NetworkInfoService
+{
+    public NetworkInfoDto GetNetworkInfo()
+    {
+        var wifi = GetWifiInterfaces();
+        var ethernet = GetEthernetInterfaces(wifi.Select(w => w.Name));
+        return new NetworkInfoDto(wifi, ethernet);
+    }
+
+    public async Task SetEthernetIpAsync(string iface, string ip, string netmask)
+    {
+        var command = $"ifconfig {iface} {ip} netmask {netmask}";
+        await RunCommandAsync(command);
+    }
+
+    private static WifiInterfaceDto[] GetWifiInterfaces()
+    {
+        var output = RunCommand("iwconfig 2>/dev/null");
+        var result = new List<WifiInterfaceDto>();
+        var lines = output.Split('\n');
+        foreach (var line in lines)
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            if (line.Contains("no wireless extensions")) continue;
+            if (!char.IsWhiteSpace(line[0]))
+            {
+                var iface = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries)[0];
+                var driverPath = RunCommand($"readlink -f /sys/class/net/{iface}/device/driver 2>/dev/null").Trim();
+                var driver = Path.GetFileName(driverPath);
+                result.Add(new WifiInterfaceDto(iface, driver));
+            }
+        }
+        return result.ToArray();
+    }
+
+    private static EthernetInterfaceDto[] GetEthernetInterfaces(IEnumerable<string> wifiNames)
+    {
+        var wifiSet = new HashSet<string>(wifiNames);
+        var output = RunCommand("ifconfig 2>/dev/null");
+        var blocks = output.Split("\n\n", StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<EthernetInterfaceDto>();
+        foreach (var block in blocks)
+        {
+            var lines = block.Split('\n');
+            if (lines.Length == 0) continue;
+            var name = lines[0].Split(':')[0];
+            if (wifiSet.Contains(name)) continue;
+            var ipMatch = Regex.Match(block, @"inet (addr:)?(?<ip>\d+\.\d+\.\d+\.\d+)");
+            var maskMatch = Regex.Match(block, @"netmask (?<mask>\d+\.\d+\.\d+\.\d+)|Mask:(?<mask>\d+\.\d+\.\d+\.\d+)");
+            var ip = ipMatch.Success ? ipMatch.Groups["ip"].Value : string.Empty;
+            var mask = maskMatch.Success ? maskMatch.Groups["mask"].Value : string.Empty;
+            result.Add(new EthernetInterfaceDto(name, ip, mask));
+        }
+        return result.ToArray();
+    }
+
+    private static async Task RunCommandAsync(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            ArgumentList = { "-c", command },
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        using var process = Process.Start(psi);
+        if (process == null) return;
+        await process.StandardOutput.ReadToEndAsync();
+        await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+    }
+
+    private static string RunCommand(string command)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            ArgumentList = { "-c", command },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        using var process = Process.Start(psi);
+        if (process == null) return string.Empty;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        return output + error;
+    }
+}

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
@@ -33,6 +33,7 @@ import { SettingsComponent } from './settings/settings.component';
         BrowserAnimationsModule,
         AppRoutingModule,
         ReactiveFormsModule,
+        FormsModule,
         MatButtonModule,
         MatCardModule,
         MatListModule

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -6,20 +6,25 @@
       Dark mode
     </label>
   </div>
-  <div class="form-group">
-    <label>
-      <input type="checkbox"> Dummy switch
-    </label>
+  <div *ngIf="network">
+    <h3>WiFi Interfaces</h3>
+    <table>
+      <tr><th>Name</th><th>Driver</th></tr>
+      <tr *ngFor="let wifi of network.wifi">
+        <td>{{wifi.name}}</td>
+        <td>{{wifi.driver}}</td>
+      </tr>
+    </table>
+
+    <h3>Ethernet Interfaces</h3>
+    <div *ngFor="let eth of network.ethernet" class="form-group">
+      <label>{{eth.name}} IP
+        <input type="text" [(ngModel)]="eth.ipAddress">
+      </label>
+      <label>Netmask
+        <input type="text" [(ngModel)]="eth.netmask">
+      </label>
+      <button (click)="saveEthernet(eth)">Save</button>
+    </div>
   </div>
-  <div class="form-group">
-    <label>Dummy slider
-      <input type="range" min="0" max="100">
-    </label>
-  </div>
-  <div class="form-group">
-    <label>Dummy text
-      <input type="text" placeholder="Enter text">
-    </label>
-  </div>
-  <p>These settings are placeholders for future configuration.</p>
 </div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 
 import { SettingsComponent } from './settings.component';
 
@@ -8,7 +10,8 @@ describe('SettingsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SettingsComponent ]
+      declarations: [ SettingsComponent ],
+      imports: [HttpClientTestingModule, FormsModule]
     })
     .compileComponents();
 

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -1,15 +1,48 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { ThemeService } from '../theme.service';
+
+interface WifiInterface {
+  name: string;
+  driver: string;
+}
+
+interface EthernetInterface {
+  name: string;
+  ipAddress: string;
+  netmask: string;
+}
+
+interface NetworkInfo {
+  wifi: WifiInterface[];
+  ethernet: EthernetInterface[];
+}
 
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.css']
 })
-export class SettingsComponent {
-  constructor(public themeService: ThemeService) {}
+export class SettingsComponent implements OnInit {
+  network?: NetworkInfo;
+
+  constructor(public themeService: ThemeService, private http: HttpClient) {}
+
+  ngOnInit(): void {
+    this.http.get<NetworkInfo>('/api/network/info').subscribe(result => {
+      this.network = result;
+    }, error => console.error(error));
+  }
 
   onThemeToggle(): void {
     this.themeService.toggle();
+  }
+
+  saveEthernet(iface: EthernetInterface): void {
+    this.http.post('/api/network/ethernet', {
+      interface: iface.name,
+      ip: iface.ipAddress,
+      netmask: iface.netmask
+    }).subscribe({ error: err => console.error(err) });
   }
 }


### PR DESCRIPTION
## Summary
- add backend service and controller to run `iwconfig`/`ifconfig`
- expose wifi interfaces, ethernet IPs, and update endpoint
- display and edit network interfaces on settings page

## Testing
- `dotnet build src/OpenHdWebUi.Server/OpenHdWebUi.Server.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `cd src/openhdwebui.client && npm test` *(fails: module not found - xterm, @angular/material)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf6b8420832f84e2a6df1d0519ee