### PR TITLE
Add editable OpenHD settings manager

### DIFF
--- a/src/OpenHdWebUi.Server/Configuration/ServiceConfiguration.cs
+++ b/src/OpenHdWebUi.Server/Configuration/ServiceConfiguration.cs
@@ -13,6 +13,8 @@ public class ServiceConfiguration
 
     public List<SystemFileConfiguration> SystemFiles { get; set; }
 
+    public List<string> SettingsDirectories { get; set; }
+
     public UpdateFileConfiguration UpdateConfig { get; set; }
 }
 

--- a/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
+++ b/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenHdWebUi.Server.Models;
+using OpenHdWebUi.Server.Services.Settings;
+
+namespace OpenHdWebUi.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    private readonly OpenHdSettingsService _settingsService;
+
+    public SettingsController(OpenHdSettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [HttpGet("files")]
+    public IReadOnlyCollection<SettingFileSummaryDto> GetFiles()
+    {
+        return _settingsService.DiscoverFiles()
+            .Select(file => new SettingFileSummaryDto(file.Id, file.Name, file.RootDirectory, file.RelativePath))
+            .ToArray();
+    }
+
+    [HttpGet("file")]
+    public async Task<ActionResult<SettingFileContentDto>> GetFile([FromQuery] string id)
+    {
+        var (found, content) = await _settingsService.TryReadAsync(id);
+        if (!found || content is null)
+        {
+            return NotFound();
+        }
+
+        if (!_settingsService.TryGetFileInfo(id, out var fileInfo))
+        {
+            return NotFound();
+        }
+
+        return new SettingFileContentDto(id, fileInfo!.Name, content);
+    }
+
+    [HttpPut("file")]
+    public async Task<ActionResult<SettingFileContentDto>> UpdateFile([FromBody] UpdateSettingFileRequest request)
+    {
+        var (updated, content, error) = await _settingsService.TryUpdateAsync(request.Id, request.Content);
+        if (!updated)
+        {
+            return BadRequest(new { error });
+        }
+
+        if (!_settingsService.TryGetFileInfo(request.Id, out var fileInfo))
+        {
+            return NotFound();
+        }
+
+        return new SettingFileContentDto(request.Id, fileInfo!.Name, content!);
+    }
+}

--- a/src/OpenHdWebUi.Server/Models/SettingsDto.cs
+++ b/src/OpenHdWebUi.Server/Models/SettingsDto.cs
@@ -1,0 +1,7 @@
+namespace OpenHdWebUi.Server.Models;
+
+public record SettingFileSummaryDto(string Id, string Name, string RootDirectory, string RelativePath);
+
+public record SettingFileContentDto(string Id, string Name, string Content);
+
+public record UpdateSettingFileRequest(string Id, string Content);

--- a/src/OpenHdWebUi.Server/Program.cs
+++ b/src/OpenHdWebUi.Server/Program.cs
@@ -7,6 +7,7 @@ using OpenHdWebUi.Server.Configuration;
 using OpenHdWebUi.Server.Services.AirGround;
 using OpenHdWebUi.Server.Services.Commands;
 using OpenHdWebUi.Server.Services.Files;
+using OpenHdWebUi.Server.Services.Settings;
 using OpenHdWebUi.Server.Services.Media;
 
 namespace OpenHdWebUi.Server;
@@ -26,7 +27,8 @@ public class Program
             .Bind(builder.Configuration);
         builder.Services
             .AddScoped<SystemCommandsService>()
-            .AddScoped<SystemFilesService>();
+            .AddScoped<SystemFilesService>()
+            .AddScoped<OpenHdSettingsService>();
         builder.Services
             .AddSingleton<MediaService>()
             .AddSingleton<AirGroundService>();

--- a/src/OpenHdWebUi.Server/Services/Settings/OpenHdSettingsService.cs
+++ b/src/OpenHdWebUi.Server/Services/Settings/OpenHdSettingsService.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using OpenHdWebUi.Server.Configuration;
+
+namespace OpenHdWebUi.Server.Services.Settings;
+
+public class OpenHdSettingsService
+{
+    private readonly ILogger<OpenHdSettingsService> _logger;
+    private readonly IReadOnlyCollection<string> _settingsDirectories;
+
+    public OpenHdSettingsService(IOptions<ServiceConfiguration> options, ILogger<OpenHdSettingsService> logger)
+    {
+        _logger = logger;
+        _settingsDirectories = (options.Value.SettingsDirectories ?? new List<string>())
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(directory => Path.GetFullPath(directory))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public IReadOnlyCollection<SettingFileInfo> DiscoverFiles()
+    {
+        var files = new ConcurrentDictionary<string, SettingFileInfo>(StringComparer.OrdinalIgnoreCase);
+
+        Parallel.ForEach(_settingsDirectories, directory =>
+        {
+            try
+            {
+                if (!Directory.Exists(directory))
+                {
+                    _logger.LogDebug("Settings directory {Directory} not found", directory);
+                    return;
+                }
+
+                foreach (var file in Directory.EnumerateFiles(directory, "*.json", SearchOption.AllDirectories))
+                {
+                    var fullPath = Path.GetFullPath(file);
+                    if (!IsPathAllowed(fullPath))
+                    {
+                        continue;
+                    }
+
+                    var relativePath = Path.GetRelativePath(directory, fullPath);
+                    var info = new SettingFileInfo(
+                        BuildId(fullPath),
+                        Path.GetFileName(fullPath),
+                        fullPath,
+                        directory,
+                        relativePath);
+
+                    files[info.Id] = info;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to enumerate settings files in {Directory}", directory);
+            }
+        });
+
+        return files.Values
+            .OrderBy(file => file.RootDirectory, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public bool TryGetFileInfo(string id, out SettingFileInfo? fileInfo)
+    {
+        fileInfo = null;
+        if (!TryDecodeId(id, out var fullPath))
+        {
+            return false;
+        }
+
+        fileInfo = DiscoverFiles().FirstOrDefault(file =>
+            string.Equals(file.FullPath, fullPath, StringComparison.OrdinalIgnoreCase));
+
+        return fileInfo != null;
+    }
+
+    public async Task<(bool Found, string? Content)> TryReadAsync(string id)
+    {
+        if (!TryGetFileInfo(id, out var fileInfo))
+        {
+            return (false, null);
+        }
+
+        try
+        {
+            var text = await File.ReadAllTextAsync(fileInfo!.FullPath);
+            return (true, TryFormatJson(text));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read settings file {File}", fileInfo!.FullPath);
+            return (false, null);
+        }
+    }
+
+    public async Task<(bool Updated, string? Content, string? Error)> TryUpdateAsync(string id, string rawContent)
+    {
+        if (!TryGetFileInfo(id, out var fileInfo))
+        {
+            return (false, null, "Settings file not found.");
+        }
+
+        try
+        {
+            using var jsonDocument = JsonDocument.Parse(rawContent);
+            var formatted = JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+
+            await File.WriteAllTextAsync(fileInfo!.FullPath, formatted + Environment.NewLine);
+            return (true, formatted, null);
+        }
+        catch (JsonException jsonException)
+        {
+            _logger.LogWarning(jsonException, "Invalid JSON provided for {File}", fileInfo!.FullPath);
+            return (false, null, "The provided content is not valid JSON.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update settings file {File}", fileInfo!.FullPath);
+            return (false, null, "Failed to save the settings file.");
+        }
+    }
+
+    private bool TryDecodeId(string id, out string fullPath)
+    {
+        fullPath = string.Empty;
+        try
+        {
+            var decodedBytes = WebEncoders.Base64UrlDecode(id);
+            var path = Encoding.UTF8.GetString(decodedBytes);
+            var absolutePath = Path.GetFullPath(path);
+
+            if (!IsPathAllowed(absolutePath) || !File.Exists(absolutePath))
+            {
+                return false;
+            }
+
+            fullPath = absolutePath;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool IsPathAllowed(string path)
+    {
+        foreach (var directory in _settingsDirectories)
+        {
+            try
+            {
+                var relative = Path.GetRelativePath(directory, path);
+                if (!relative.StartsWith("..", StringComparison.Ordinal) && !Path.IsPathRooted(relative))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // ignored - we'll keep checking other directories
+            }
+        }
+
+        return false;
+    }
+
+    private static string TryFormatJson(string content)
+    {
+        try
+        {
+            using var jsonDocument = JsonDocument.Parse(content);
+            return JsonSerializer.Serialize(jsonDocument.RootElement, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+        }
+        catch
+        {
+            return content;
+        }
+    }
+
+    public static string BuildId(string fullPath)
+    {
+        var bytes = Encoding.UTF8.GetBytes(fullPath);
+        return WebEncoders.Base64UrlEncode(bytes);
+    }
+}
+
+public record SettingFileInfo(string Id, string Name, string FullPath, string RootDirectory, string RelativePath);

--- a/src/OpenHdWebUi.Server/appsettings.Development.json
+++ b/src/OpenHdWebUi.Server/appsettings.Development.json
@@ -12,6 +12,10 @@
     "/Videos",
     "C:\\testData\\media"
   ],
+  "SettingsDirectories": [
+    "/etc/openhd",
+    "C:\\testData\\settings"
+  ],
   "UpdateConfig": {
     "UpdateFile": "C:\\testData\\update.zip"
   }

--- a/src/OpenHdWebUi.Server/appsettings.json
+++ b/src/OpenHdWebUi.Server/appsettings.json
@@ -46,6 +46,10 @@
       "Path": "/boot/openhd_version.txt"
     }
   ],
+  "SettingsDirectories": [
+    "/etc/openhd",
+    "/usr/local/share/openhd/settings"
+  ],
   "UpdateConfig": {
     "UpdateFile": "/usr/local/share/openhd/update.zip"
   }

--- a/src/openhdwebui.client/angular.json
+++ b/src/openhdwebui.client/angular.json
@@ -107,5 +107,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/openhdwebui.client/src/app/app-routing.module.ts
+++ b/src/openhdwebui.client/src/app/app-routing.module.ts
@@ -3,10 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
+import { SettingsComponent } from './settings/settings.component';
 
-const routes: Routes = 
+const routes: Routes =
 [
-  { path: '', component: FilesComponent, pathMatch: 'full' },
+  { path: '', component: SettingsComponent, pathMatch: 'full' },
+  { path: 'settings', component: SettingsComponent },
   { path: 'files', component: FilesComponent },
   { path: 'system', component: SystemComponent },
   { path: 'update', component: UpdateComponent }

--- a/src/openhdwebui.client/src/app/app.module.ts
+++ b/src/openhdwebui.client/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -8,6 +9,7 @@ import { NavMenuComponent } from './nav-menu/nav-menu.component';
 import { FilesComponent } from './files/files.component';
 import { SystemComponent } from './system/system.component';
 import { UpdateComponent } from './update/update.component';
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule(
     { 
@@ -17,13 +19,15 @@ import { UpdateComponent } from './update/update.component';
             NavMenuComponent,
             FilesComponent,
             SystemComponent,
-            UpdateComponent
+            UpdateComponent,
+            SettingsComponent
         ],
         bootstrap: [AppComponent], 
         imports: 
         [
             BrowserModule,
-            AppRoutingModule
+            AppRoutingModule,
+            FormsModule
         ], 
         providers: 
             [

--- a/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
+++ b/src/openhdwebui.client/src/app/nav-menu/nav-menu.component.html
@@ -29,6 +29,11 @@
       </button>
       <div class="navbar-collapse collapse d-sm-inline-flex justify-content-end"
            [ngClass]="{ show: isExpanded }">
+        <ul class="navbar-nav flex-grow">
+          <li class="nav-item" [routerLinkActive]="['link-active']">
+            <a class="nav-link text-dark" [routerLink]="['/settings']">Settings</a>
+          </li>
+        </ul>
         <ul class="navbar-nav flex-grow" *ngIf="isAir">
           <li class="nav-item" [routerLinkActive]="['link-active']">
             <a class="nav-link text-dark" [routerLink]="['/files']">Files</a>

--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -1,0 +1,41 @@
+.settings-container {
+  display: flex;
+  flex-direction: row;
+  gap: 1.5rem;
+}
+
+.settings-sidebar {
+  width: 320px;
+  max-height: calc(100vh - 180px);
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+
+.settings-editor {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-textarea {
+  min-height: 420px;
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.95rem;
+  white-space: pre;
+}
+
+@media (max-width: 992px) {
+  .settings-container {
+    flex-direction: column;
+  }
+
+  .settings-sidebar {
+    width: 100%;
+    max-height: none;
+  }
+}

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -1,0 +1,69 @@
+<div class="settings-container" *ngIf="!isLoadingList || filteredFiles.length > 0">
+  <div class="settings-sidebar">
+    <div class="d-flex align-items-center mb-3">
+      <input
+        type="search"
+        class="form-control"
+        placeholder="Search settings files"
+        [(ngModel)]="searchTerm"
+        (ngModelChange)="onSearchTermChange()"
+      />
+    </div>
+    <div class="list-group settings-list">
+      <button
+        type="button"
+        class="list-group-item list-group-item-action"
+        *ngFor="let file of filteredFiles"
+        [ngClass]="{ active: file.id === selectedFile?.id }"
+        (click)="selectFile(file)"
+      >
+        <div class="fw-semibold">{{ file.name }}</div>
+        <small class="text-muted d-block">{{ file.relativePath }}</small>
+        <small class="text-muted d-block">{{ file.rootDirectory }}</small>
+      </button>
+    </div>
+    <div *ngIf="filteredFiles.length === 0 && !isLoadingList" class="text-muted text-center mt-4">
+      No settings files were found.
+    </div>
+  </div>
+
+  <div class="settings-editor" *ngIf="selectedFile">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <h2 class="h5 mb-0">{{ selectedFile.name }}</h2>
+      <div class="btn-group">
+        <button class="btn btn-outline-secondary" type="button" (click)="formatContent()" [disabled]="!fileContent">
+          Format JSON
+        </button>
+        <button class="btn btn-primary" type="button" (click)="saveChanges()" [disabled]="isSaving || !fileContent">
+          <span *ngIf="isSaving" class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          Save Changes
+        </button>
+      </div>
+    </div>
+    <p class="text-muted small">{{ selectedFile.rootDirectory }}/{{ selectedFile.relativePath }}</p>
+
+    <textarea
+      class="form-control settings-textarea"
+      [(ngModel)]="fileContent"
+      spellcheck="false"
+      [readonly]="isLoadingContent"
+    ></textarea>
+
+    <div class="text-muted small mt-2" *ngIf="isLoadingContent">
+      Loading file contents...
+    </div>
+
+    <div class="alert alert-danger mt-3" role="alert" *ngIf="errorMessage">
+      {{ errorMessage }}
+    </div>
+    <div class="alert alert-success mt-3" role="alert" *ngIf="successMessage">
+      {{ successMessage }}
+    </div>
+  </div>
+
+  <div class="flex-fill d-flex justify-content-center align-items-center" *ngIf="isLoadingList && filteredFiles.length === 0">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+  </div>
+</div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.spec.ts
@@ -1,0 +1,26 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SettingsComponent],
+      imports: [HttpClientTestingModule, FormsModule]
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -1,0 +1,168 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { finalize } from 'rxjs/operators';
+
+interface SettingFileSummary {
+  id: string;
+  name: string;
+  rootDirectory: string;
+  relativePath: string;
+}
+
+interface SettingFileContent {
+  id: string;
+  name: string;
+  content: string;
+}
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.css']
+})
+export class SettingsComponent implements OnInit {
+  public isLoadingContent = false;
+  public isLoadingList = false;
+  public isSaving = false;
+  public errorMessage: string | null = null;
+  public successMessage: string | null = null;
+
+  public files: SettingFileSummary[] = [];
+  public filteredFiles: SettingFileSummary[] = [];
+  public selectedFile: SettingFileSummary | null = null;
+  public fileContent = '';
+  public searchTerm = '';
+
+  constructor(private httpClient: HttpClient) { }
+
+  ngOnInit(): void {
+    this.loadFiles();
+  }
+
+  loadFiles(): void {
+    this.isLoadingList = true;
+    this.clearMessages();
+    this.httpClient.get<SettingFileSummary[]>('/api/settings/files')
+      .pipe(finalize(() => {
+        this.isLoadingList = false;
+      }))
+      .subscribe({
+        next: files => {
+          this.files = files;
+          this.applyFilter();
+        },
+        error: error => this.handleError('Unable to load settings files.', error)
+      });
+  }
+
+  applyFilter(): void {
+    const term = this.searchTerm.trim().toLowerCase();
+    if (!term) {
+      this.filteredFiles = [...this.files];
+    } else {
+      this.filteredFiles = this.files.filter(file =>
+        file.name.toLowerCase().includes(term) ||
+        file.relativePath.toLowerCase().includes(term) ||
+        file.rootDirectory.toLowerCase().includes(term));
+    }
+
+    if (this.selectedFile && !this.filteredFiles.some(file => file.id === this.selectedFile?.id)) {
+      this.selectedFile = null;
+      this.fileContent = '';
+    }
+
+    if (!this.selectedFile && this.filteredFiles.length > 0) {
+      this.selectFile(this.filteredFiles[0]);
+    }
+  }
+
+  onSearchTermChange(): void {
+    this.applyFilter();
+  }
+
+  selectFile(file: SettingFileSummary): void {
+    if (this.selectedFile?.id === file.id && this.fileContent) {
+      return;
+    }
+
+    this.selectedFile = file;
+    this.fileContent = '';
+    this.isLoadingContent = true;
+    this.clearMessages();
+    this.httpClient.get<SettingFileContent>('/api/settings/file', { params: { id: file.id } })
+      .pipe(finalize(() => {
+        this.isLoadingContent = false;
+      }))
+      .subscribe({
+        next: content => {
+          this.fileContent = content.content;
+        },
+        error: error => this.handleError('Unable to load the selected settings file.', error)
+      });
+  }
+
+  formatContent(): void {
+    if (!this.fileContent) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(this.fileContent);
+      this.fileContent = JSON.stringify(parsed, null, 2);
+      this.successMessage = 'JSON formatted successfully.';
+      this.errorMessage = null;
+    } catch (error) {
+      this.errorMessage = 'The current content is not valid JSON and cannot be formatted.';
+      this.successMessage = null;
+    }
+  }
+
+  saveChanges(): void {
+    if (!this.selectedFile) {
+      return;
+    }
+
+    this.clearMessages();
+
+    try {
+      JSON.parse(this.fileContent);
+    } catch (error) {
+      this.errorMessage = 'Please fix the JSON errors before saving.';
+      return;
+    }
+
+    this.isSaving = true;
+    const payload = { id: this.selectedFile.id, content: this.fileContent };
+    this.httpClient.put<SettingFileContent>('/api/settings/file', payload)
+      .pipe(finalize(() => {
+        this.isSaving = false;
+      }))
+      .subscribe({
+        next: response => {
+          this.fileContent = response.content;
+          this.successMessage = 'Settings saved successfully.';
+        },
+        error: error => this.handleError('Unable to save the settings file.', error)
+      });
+  }
+
+  clearMessages(): void {
+    this.errorMessage = null;
+    this.successMessage = null;
+  }
+
+  private handleError(message: string, error: unknown): void {
+    console.error(message, error);
+    let errorDetail = '';
+    if (error instanceof HttpErrorResponse) {
+      if (error.error && typeof error.error === 'object' && 'error' in error.error) {
+        errorDetail = ` ${error.error.error}`;
+      } else if (typeof error.error === 'string') {
+        errorDetail = ` ${error.error}`;
+      }
+    }
+
+    this.errorMessage = `${message}${errorDetail}`;
+    this.successMessage = null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a backend settings service and controller that discovers OpenHD JSON configuration files and supports validated read/write operations
- expose configurable settings directories in appsettings for production and development environments
- build a dedicated Angular settings page with search, formatting, and save workflows and link it from navigation/default routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57335f9d4832f933ad2a9d152a682