### PR TITLE
Add OpenHD settings editor

### DIFF
--- a/src/OpenHdWebUi.Server/Configuration/ServiceConfiguration.cs
+++ b/src/OpenHdWebUi.Server/Configuration/ServiceConfiguration.cs
@@ -13,6 +13,8 @@ public class ServiceConfiguration
 
     public List<SystemFileConfiguration> SystemFiles { get; set; }
 
+    public List<string> SettingsDirectories { get; set; }
+
     public UpdateFileConfiguration UpdateConfig { get; set; }
 }
 

--- a/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
+++ b/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
@@ -1,0 +1,63 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenHdWebUi.Server.Models;
+using OpenHdWebUi.Server.Services.Settings;
+
+namespace OpenHdWebUi.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class SettingsController : ControllerBase
+{
+    private readonly SettingsService _settingsService;
+
+    public SettingsController(SettingsService settingsService)
+    {
+        _settingsService = settingsService;
+    }
+
+    [HttpGet]
+    public ActionResult<IReadOnlyCollection<SettingFileSummaryDto>> GetSettings()
+    {
+        var summaries = _settingsService.GetSettingFiles();
+        return Ok(summaries);
+    }
+
+    [HttpGet("{id}")]
+    public ActionResult<SettingFileDto> GetSetting(string id)
+    {
+        var file = _settingsService.GetSettingFile(id);
+        if (file == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(file);
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult UpdateSetting(string id, [FromBody] UpdateSettingFileRequest request)
+    {
+        if (request == null)
+        {
+            return BadRequest();
+        }
+
+        var updated = _settingsService.TrySaveSettingFile(id, request.Content, out var file, out var notFound);
+        if (!updated)
+        {
+            if (notFound)
+            {
+                return NotFound();
+            }
+
+            return Problem("Unable to save the requested settings file.");
+        }
+
+        if (file == null)
+        {
+            return Problem("Unable to reload the settings file after saving.");
+        }
+
+        return Ok(file);
+    }
+}

--- a/src/OpenHdWebUi.Server/Models/Records.cs
+++ b/src/OpenHdWebUi.Server/Models/Records.cs
@@ -20,3 +20,9 @@ public record EthernetInterfaceDto(string Name, string IpAddress, string Netmask
 public record NetworkInfoDto(IReadOnlyCollection<WifiInterfaceDto> Wifi, IReadOnlyCollection<EthernetInterfaceDto> Ethernet);
 
 public record SetIpRequest(string Interface, string Ip, string Netmask);
+
+public record SettingFileSummaryDto(string Id, string Name, string RelativePath, string? Category);
+
+public record SettingFileDto(string Id, string Name, string RelativePath, string? Category, string Content);
+
+public record UpdateSettingFileRequest(string Content);

--- a/src/OpenHdWebUi.Server/Program.cs
+++ b/src/OpenHdWebUi.Server/Program.cs
@@ -9,6 +9,7 @@ using OpenHdWebUi.Server.Services.Commands;
 using OpenHdWebUi.Server.Services.Files;
 using OpenHdWebUi.Server.Services.Media;
 using OpenHdWebUi.Server.Services.Network;
+using OpenHdWebUi.Server.Services.Settings;
 
 namespace OpenHdWebUi.Server;
 
@@ -31,7 +32,8 @@ public class Program
             .AddScoped<NetworkInfoService>();
         builder.Services
             .AddSingleton<MediaService>()
-            .AddSingleton<AirGroundService>();
+            .AddSingleton<AirGroundService>()
+            .AddSingleton<SettingsService>();
         builder.Services
             .AddDirectoryBrowser()
             .AddControllers();

--- a/src/OpenHdWebUi.Server/Services/Settings/SettingsService.cs
+++ b/src/OpenHdWebUi.Server/Services/Settings/SettingsService.cs
@@ -1,0 +1,188 @@
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using OpenHdWebUi.Server.Configuration;
+using OpenHdWebUi.Server.Models;
+
+namespace OpenHdWebUi.Server.Services.Settings;
+
+public class SettingsService
+{
+    private readonly ILogger<SettingsService> _logger;
+    private readonly string[] _settingsRoots;
+
+    public SettingsService(ILogger<SettingsService> logger, IOptions<ServiceConfiguration> configuration)
+    {
+        _logger = logger;
+        _settingsRoots = configuration.Value.SettingsDirectories?
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Select(directory => Path.GetFullPath(directory))
+            .Where(Directory.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? Array.Empty<string>();
+
+        if (_settingsRoots.Length == 0)
+        {
+            _logger.LogInformation("No settings directories configured or available.");
+        }
+        else
+        {
+            foreach (var root in _settingsRoots)
+            {
+                _logger.LogInformation("Settings directory registered: {SettingsDirectory}", root);
+            }
+        }
+    }
+
+    public IReadOnlyCollection<SettingFileSummaryDto> GetSettingFiles()
+    {
+        var summaries = new List<SettingFileSummaryDto>();
+
+        foreach (var root in _settingsRoots)
+        {
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(root, "*.json", SearchOption.AllDirectories))
+                {
+                    var fullPath = Path.GetFullPath(file);
+                    if (!IsPathInRoot(fullPath))
+                    {
+                        continue;
+                    }
+
+                    var relativePath = Path.GetRelativePath(root, fullPath);
+                    var category = ExtractCategory(relativePath);
+                    var id = EncodePath(fullPath);
+                    summaries.Add(new SettingFileSummaryDto(id, Path.GetFileName(fullPath), NormalizeSeparators(relativePath), category));
+                }
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "Failed to enumerate settings directory {SettingsDirectory}", root);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogError(ex, "Access denied while enumerating settings directory {SettingsDirectory}", root);
+            }
+        }
+
+        return summaries
+            .OrderBy(summary => summary.Category ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(summary => summary.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public SettingFileDto? GetSettingFile(string id)
+    {
+        var fullPath = DecodeAndValidate(id);
+        if (fullPath == null || !File.Exists(fullPath))
+        {
+            return null;
+        }
+
+        var root = ResolveRoot(fullPath);
+        var relativePath = root != null ? Path.GetRelativePath(root, fullPath) : Path.GetFileName(fullPath);
+        var category = ExtractCategory(relativePath);
+        try
+        {
+            var content = File.ReadAllText(fullPath);
+            return new SettingFileDto(id, Path.GetFileName(fullPath), NormalizeSeparators(relativePath), category, content);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "Failed to read settings file {SettingsFile}", fullPath);
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex, "Access denied while reading settings file {SettingsFile}", fullPath);
+            return null;
+        }
+    }
+
+    public bool TrySaveSettingFile(string id, string content, out SettingFileDto? updated, out bool notFound)
+    {
+        updated = null;
+        notFound = false;
+        var fullPath = DecodeAndValidate(id);
+        if (fullPath == null || !File.Exists(fullPath))
+        {
+            notFound = true;
+            return false;
+        }
+
+        try
+        {
+            File.WriteAllText(fullPath, content);
+        }
+        catch (IOException ex)
+        {
+            _logger.LogError(ex, "Failed to write settings file {SettingsFile}", fullPath);
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.LogError(ex, "Access denied while writing settings file {SettingsFile}", fullPath);
+            return false;
+        }
+
+        updated = GetSettingFile(id);
+        return updated != null;
+    }
+
+    private static string? ExtractCategory(string relativePath)
+    {
+        if (string.IsNullOrWhiteSpace(relativePath))
+        {
+            return null;
+        }
+
+        var normalized = NormalizeSeparators(relativePath);
+        var separatorIndex = normalized.IndexOf('/');
+        return separatorIndex > 0 ? normalized[..separatorIndex] : null;
+    }
+
+    private static string NormalizeSeparators(string path)
+    {
+        return path.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private string? DecodeAndValidate(string id)
+    {
+        try
+        {
+            var pathBytes = WebEncoders.Base64UrlDecode(id);
+            var decodedPath = Encoding.UTF8.GetString(pathBytes);
+            var fullPath = Path.GetFullPath(decodedPath);
+            return IsPathInRoot(fullPath) ? fullPath : null;
+        }
+        catch (FormatException ex)
+        {
+            _logger.LogWarning(ex, "Failed to decode settings file id: {Id}", id);
+            return null;
+        }
+    }
+
+    private bool IsPathInRoot(string fullPath)
+    {
+        return _settingsRoots.Any(root => IsPathUnderRoot(fullPath, root));
+    }
+
+    private string EncodePath(string path)
+    {
+        var bytes = Encoding.UTF8.GetBytes(Path.GetFullPath(path));
+        return WebEncoders.Base64UrlEncode(bytes);
+    }
+
+    private string? ResolveRoot(string fullPath)
+    {
+        return _settingsRoots.FirstOrDefault(root => IsPathUnderRoot(fullPath, root));
+    }
+
+    private static bool IsPathUnderRoot(string fullPath, string root)
+    {
+        var relative = Path.GetRelativePath(root, fullPath);
+        return !relative.StartsWith("..", StringComparison.Ordinal) && !Path.IsPathRooted(relative);
+    }
+}

--- a/src/OpenHdWebUi.Server/appsettings.Development.json
+++ b/src/OpenHdWebUi.Server/appsettings.Development.json
@@ -12,6 +12,10 @@
     "/Videos",
     "C:\\testData\\media"
   ],
+  "SettingsDirectories": [
+    "C:\\testData\\settings",
+    "/usr/local/share/openhd/settings"
+  ],
   "UpdateConfig": {
     "UpdateFile": "C:\\testData\\update.zip"
   }

--- a/src/OpenHdWebUi.Server/appsettings.json
+++ b/src/OpenHdWebUi.Server/appsettings.json
@@ -46,6 +46,10 @@
       "Path": "/boot/openhd_version.txt"
     }
   ],
+  "SettingsDirectories": [
+    "/usr/local/share/openhd/settings",
+    "/boot/openhd/settings"
+  ],
   "UpdateConfig": {
     "UpdateFile": "/usr/local/share/openhd/update.zip"
   }

--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -1,8 +1,380 @@
 .settings {
-  max-width: 600px;
+  width: 100%;
+  max-width: 1100px;
   margin: 0 auto;
+  padding: 1rem;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: #f5f7fb;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 14px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
+}
+
+:host-context(.dark-theme) .card {
+  background-color: #2b3845;
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: none;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.toggle input {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.network-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.network-column {
+  flex: 1 1 280px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+:host-context(.dark-theme) th,
+:host-context(.dark-theme) td {
+  border-color: rgba(255, 255, 255, 0.12);
 }
 
 .form-group {
-  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.75rem;
+}
+
+.form-group input {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: inherit;
+}
+
+:host-context(.dark-theme) .form-group input {
+  background-color: rgba(21, 30, 39, 0.9);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.form-group button {
+  align-self: flex-start;
+  padding: 0.45rem 1rem;
+  border-radius: 6px;
+  border: none;
+  background-color: var(--primary-color);
+  color: var(--text-color);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.18);
+}
+
+.settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.settings-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.settings-header h3 {
+  margin: 0 0 0.25rem;
+}
+
+.settings-header .description {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+:host-context(.dark-theme) .settings-header .description {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.status {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.status.error {
+  color: #d9534f;
+}
+
+:host-context(.dark-theme) .status {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+:host-context(.dark-theme) .status.error {
+  color: #ff6b6b;
+}
+
+.settings-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.settings-list {
+  flex: 1 1 280px;
+  max-width: 320px;
+  border-right: 1px solid rgba(15, 23, 42, 0.08);
+  padding-right: 1rem;
+  max-height: 520px;
+  overflow-y: auto;
+}
+
+.settings-list.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+:host-context(.dark-theme) .settings-list {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.settings-list h4 {
+  margin: 0.75rem 0 0.4rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+:host-context(.dark-theme) .settings-list h4 {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.settings-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.settings-list li {
+  padding: 0.6rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.45rem;
+}
+
+.settings-list li:hover {
+  background-color: rgba(0, 166, 242, 0.1);
+  transform: translateX(4px);
+}
+
+.settings-list li.active {
+  background-color: rgba(0, 166, 242, 0.18);
+}
+
+:host-context(.dark-theme) .settings-list li:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+:host-context(.dark-theme) .settings-list li.active {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.file-name {
+  font-weight: 600;
+}
+
+.file-path {
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.6);
+  word-break: break-word;
+}
+
+:host-context(.dark-theme) .file-path {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.settings-list .empty {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+:host-context(.dark-theme) .settings-list .empty {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.settings-editor {
+  flex: 2 1 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.settings-editor.placeholder {
+  justify-content: center;
+  align-items: center;
+  border: 2px dashed rgba(15, 23, 42, 0.12);
+  border-radius: 12px;
+  color: rgba(15, 23, 42, 0.6);
+  text-align: center;
+  padding: 2rem;
+}
+
+:host-context(.dark-theme) .settings-editor.placeholder {
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.editor-header h4 {
+  margin: 0;
+}
+
+.editor-path {
+  display: block;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.6);
+  margin-top: 0.2rem;
+  word-break: break-word;
+}
+
+:host-context(.dark-theme) .editor-path {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.editor-status {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.editor-status .info {
+  color: #007bff;
+}
+
+.editor-status .success {
+  color: #2e8540;
+}
+
+.editor-status .error {
+  color: #d9534f;
+}
+
+textarea {
+  width: 100%;
+  min-height: 320px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background-color: rgba(255, 255, 255, 0.92);
+  color: inherit;
+  padding: 1rem;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+:host-context(.dark-theme) textarea {
+  background-color: rgba(21, 30, 39, 0.9);
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+textarea:disabled {
+  opacity: 0.7;
+}
+
+.editor-actions {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.editor-actions button {
+  padding: 0.6rem 1.2rem;
+  border-radius: 8px;
+  border: none;
+  background-color: var(--primary-color);
+  color: var(--text-color);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.editor-actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.editor-actions button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.18);
+}
+
+@media (max-width: 900px) {
+  .settings-list {
+    max-width: none;
+    border-right: none;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    padding-right: 0;
+    padding-bottom: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  :host-context(.dark-theme) .settings-list {
+    border-bottom-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .settings-content {
+    flex-direction: column;
+  }
 }

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -1,30 +1,94 @@
 <div class="settings">
   <h2>Settings</h2>
-  <div class="form-group">
-    <label>
-      <input type="checkbox" (change)="onThemeToggle()" [checked]="themeService.isDark">
-      Dark mode
-    </label>
-  </div>
-  <div *ngIf="network">
-    <h3>WiFi Interfaces</h3>
-    <table>
-      <tr><th>Name</th><th>Driver</th></tr>
-      <tr *ngFor="let wifi of network.wifi">
-        <td>{{wifi.name}}</td>
-        <td>{{wifi.driver}}</td>
-      </tr>
-    </table>
 
-    <h3>Ethernet Interfaces</h3>
-    <div *ngFor="let eth of network.ethernet" class="form-group">
-      <label>{{eth.name}} IP
-        <input type="text" [(ngModel)]="eth.ipAddress">
-      </label>
-      <label>Netmask
-        <input type="text" [(ngModel)]="eth.netmask">
-      </label>
-      <button (click)="saveEthernet(eth)">Save</button>
+  <section class="card">
+    <h3>Theme</h3>
+    <label class="toggle">
+      <input type="checkbox" (change)="onThemeToggle()" [checked]="themeService.isDark">
+      <span>Dark mode</span>
+    </label>
+  </section>
+
+  <section class="card" *ngIf="network">
+    <h3>Network</h3>
+    <div class="network-grid">
+      <div class="network-column">
+        <h4>WiFi Interfaces</h4>
+        <table>
+          <thead>
+            <tr><th>Name</th><th>Driver</th></tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let wifi of network.wifi">
+              <td>{{ wifi.name }}</td>
+              <td>{{ wifi.driver }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="network-column">
+        <h4>Ethernet Interfaces</h4>
+        <div *ngFor="let eth of network.ethernet" class="form-group">
+          <label>{{ eth.name }} IP
+            <input type="text" [(ngModel)]="eth.ipAddress">
+          </label>
+          <label>Netmask
+            <input type="text" [(ngModel)]="eth.netmask">
+          </label>
+          <button (click)="saveEthernet(eth)">Save</button>
+        </div>
+      </div>
     </div>
-  </div>
+  </section>
+
+  <section class="card settings-card">
+    <div class="settings-header">
+      <div>
+        <h3>OpenHD configuration</h3>
+        <p class="description">Select a JSON settings file from OpenHD and edit it directly in the browser.</p>
+      </div>
+      <div class="status" *ngIf="isLoadingSettings">Loading settings…</div>
+      <div class="status error" *ngIf="settingsError">{{ settingsError }}</div>
+    </div>
+
+    <div class="settings-content" *ngIf="!settingsError">
+      <div class="settings-list" [class.disabled]="isLoadingSettings">
+        <p *ngIf="!isLoadingSettings && settingFiles.length === 0" class="empty">No settings files were found. Ensure OpenHD is installed and the settings directory is accessible.</p>
+        <ng-container *ngFor="let group of groupedSettings">
+          <h4>{{ group.title }}</h4>
+          <ul>
+            <li *ngFor="let file of group.items; trackBy: trackBySetting"
+                (click)="selectSetting(file)"
+                [class.active]="selectedSetting?.id === file.id">
+              <span class="file-name">{{ file.name }}</span>
+              <span class="file-path">{{ file.relativePath }}</span>
+            </li>
+          </ul>
+        </ng-container>
+      </div>
+
+      <div class="settings-editor" *ngIf="selectedSetting">
+        <div class="editor-header">
+          <div>
+            <h4>{{ selectedSetting.name }}</h4>
+            <span class="editor-path">{{ selectedSetting.relativePath }}</span>
+          </div>
+          <div class="editor-status">
+            <span class="info" *ngIf="isSavingFile">Saving…</span>
+            <span class="info" *ngIf="isLoadingFile">Loading…</span>
+            <span class="success" *ngIf="saveSuccess">Saved</span>
+            <span class="error" *ngIf="fileError">{{ fileError }}</span>
+          </div>
+        </div>
+        <textarea [(ngModel)]="selectedSetting.content" [disabled]="isLoadingFile || isSavingFile"></textarea>
+        <div class="editor-actions">
+          <button (click)="saveSelectedSetting()" [disabled]="isSavingFile">Save changes</button>
+        </div>
+      </div>
+
+      <div class="settings-editor placeholder" *ngIf="!selectedSetting && !isLoadingSettings && settingFiles.length > 0">
+        <p>Select a settings file to start editing its contents.</p>
+      </div>
+    </div>
+  </section>
 </div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -18,6 +18,17 @@ interface NetworkInfo {
   ethernet: EthernetInterface[];
 }
 
+interface SettingFileSummary {
+  id: string;
+  name: string;
+  relativePath: string;
+  category?: string;
+}
+
+interface SettingFileDetail extends SettingFileSummary {
+  content: string;
+}
+
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
@@ -25,17 +36,80 @@ interface NetworkInfo {
 })
 export class SettingsComponent implements OnInit {
   network?: NetworkInfo;
+  settingFiles: SettingFileSummary[] = [];
+  selectedSetting?: SettingFileDetail;
+  settingsError?: string;
+  fileError?: string;
+  isLoadingSettings = false;
+  isLoadingFile = false;
+  isSavingFile = false;
+  saveSuccess = false;
 
   constructor(public themeService: ThemeService, private http: HttpClient) {}
 
   ngOnInit(): void {
-    this.http.get<NetworkInfo>('/api/network/info').subscribe(result => {
-      this.network = result;
-    }, error => console.error(error));
+    this.loadNetworkInformation();
+    this.loadSettingFiles();
   }
 
   onThemeToggle(): void {
     this.themeService.toggle();
+  }
+
+  get groupedSettings(): { title: string; items: SettingFileSummary[] }[] {
+    const groups = new Map<string, SettingFileSummary[]>();
+    for (const file of this.settingFiles) {
+      const key = file.category ?? 'Ungrouped';
+      if (!groups.has(key)) {
+        groups.set(key, []);
+      }
+      groups.get(key)!.push(file);
+    }
+
+    return Array.from(groups.entries())
+      .map(([title, items]) => ({ title, items: items.sort((a, b) => a.name.localeCompare(b.name)) }))
+      .sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  trackBySetting(_index: number, item: SettingFileSummary): string {
+    return item.id;
+  }
+
+  selectSetting(file: SettingFileSummary): void {
+    if (this.selectedSetting && this.selectedSetting.id === file.id) {
+      return;
+    }
+
+    this.fetchSettingFile(file.id);
+  }
+
+  saveSelectedSetting(): void {
+    if (!this.selectedSetting || this.isSavingFile) {
+      return;
+    }
+
+    this.isSavingFile = true;
+    this.saveSuccess = false;
+    this.fileError = undefined;
+
+    this.http
+      .put<SettingFileDetail>(`/api/settings/${this.selectedSetting.id}`, { content: this.selectedSetting.content })
+      .subscribe({
+      next: updated => {
+        this.selectedSetting = updated;
+        this.isSavingFile = false;
+        this.saveSuccess = true;
+        this.updateSummary(updated);
+        setTimeout(() => {
+          this.saveSuccess = false;
+        }, 2500);
+      },
+      error: err => {
+        this.isSavingFile = false;
+        this.fileError = err?.error?.title ?? 'Unable to save settings file.';
+        console.error(err);
+      }
+      });
   }
 
   saveEthernet(iface: EthernetInterface): void {
@@ -44,5 +118,58 @@ export class SettingsComponent implements OnInit {
       ip: iface.ipAddress,
       netmask: iface.netmask
     }).subscribe({ error: err => console.error(err) });
+  }
+
+  private loadNetworkInformation(): void {
+    this.http.get<NetworkInfo>('/api/network/info').subscribe(result => {
+      this.network = result;
+    }, error => console.error(error));
+  }
+
+  private loadSettingFiles(): void {
+    this.isLoadingSettings = true;
+    this.settingsError = undefined;
+    this.http.get<SettingFileSummary[]>('/api/settings').subscribe({
+      next: files => {
+        this.settingFiles = files;
+        this.isLoadingSettings = false;
+        if (files.length > 0) {
+          this.fetchSettingFile(files[0].id);
+        } else {
+          this.selectedSetting = undefined;
+        }
+      },
+      error: err => {
+        this.isLoadingSettings = false;
+        this.settingsError = err?.error?.title ?? 'Unable to load settings files.';
+        console.error(err);
+      }
+    });
+  }
+
+  private fetchSettingFile(id: string): void {
+    this.isLoadingFile = true;
+    this.fileError = undefined;
+    if (!this.selectedSetting || this.selectedSetting.id !== id) {
+      this.selectedSetting = undefined;
+    }
+    this.http.get<SettingFileDetail>(`/api/settings/${id}`).subscribe({
+      next: file => {
+        this.selectedSetting = file;
+        this.isLoadingFile = false;
+      },
+      error: err => {
+        this.isLoadingFile = false;
+        this.fileError = err?.error?.title ?? 'Unable to load the selected settings file.';
+        console.error(err);
+      }
+    });
+  }
+
+  private updateSummary(updated: SettingFileSummary): void {
+    const index = this.settingFiles.findIndex(file => file.id === updated.id);
+    if (index >= 0) {
+      this.settingFiles[index] = { ...updated };
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a settings service and controller to expose OpenHD JSON configuration files for editing
- extend server configuration to know where to discover settings directories by default
- refresh the Angular settings page with a file list, editor, and richer styling for managing settings files

## Testing
- dotnet build *(fails: dotnet is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d65b78fb30832faca23436a8c11ff2