### PR TITLE
Ensure deb artifacts are uploaded when Cloudsmith push fails

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -37,3 +37,10 @@ jobs:
         run: ./build.cmd Clean CloudsmithPublish
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+      - name: 'Upload deb artifacts'
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-packages
+          path: out/deb/*.deb
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary
- add an artifact upload step to the workflow so .deb packages are collected even if the Cloudsmith push fails

## Testing
- not run (CI)


------
https://chatgpt.com/codex/tasks/task_e_68d6af32b5fc832fbf0b8f587b82c13e