### PR TITLE
Improve settings JSON discovery and validation

### DIFF
--- a/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
+++ b/src/OpenHdWebUi.Server/Controllers/SettingsController.cs
@@ -42,12 +42,17 @@ public class SettingsController : ControllerBase
             return BadRequest();
         }
 
-        var updated = _settingsService.TrySaveSettingFile(id, request.Content, out var file, out var notFound);
+        var updated = _settingsService.TrySaveSettingFile(id, request.Content, out var file, out var notFound, out var invalidJson);
         if (!updated)
         {
             if (notFound)
             {
                 return NotFound();
+            }
+
+            if (invalidJson)
+            {
+                return BadRequest("The provided settings file is not valid JSON.");
             }
 
             return Problem("Unable to save the requested settings file.");

--- a/src/OpenHdWebUi.Server/appsettings.Development.json
+++ b/src/OpenHdWebUi.Server/appsettings.Development.json
@@ -13,7 +13,9 @@
     "C:\\testData\\media"
   ],
   "SettingsDirectories": [
+    "C:\\testData\\openhd",
     "C:\\testData\\settings",
+    "/usr/local/share/openhd",
     "/usr/local/share/openhd/settings"
   ],
   "UpdateConfig": {

--- a/src/OpenHdWebUi.Server/appsettings.json
+++ b/src/OpenHdWebUi.Server/appsettings.json
@@ -47,7 +47,9 @@
     }
   ],
   "SettingsDirectories": [
+    "/usr/local/share/openhd",
     "/usr/local/share/openhd/settings",
+    "/boot/openhd",
     "/boot/openhd/settings"
   ],
   "UpdateConfig": {


### PR DESCRIPTION
## Summary
- include the current OpenHD settings roots in the service configuration
- skip compiled web-ui assets and de-duplicate discovered JSON files
- validate JSON content before saving and surface invalid payload errors to the client

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6c2f1b0a4832fabfa694558b2393b