### PR TITLE
Add structured settings UI controls

### DIFF
--- a/src/openhdwebui.client/src/app/settings/settings-metadata.ts
+++ b/src/openhdwebui.client/src/app/settings/settings-metadata.ts
@@ -1,0 +1,463 @@
+export type SettingValueType = 'boolean' | 'number' | 'string';
+
+export interface SettingFieldOption {
+  value: string | number | boolean;
+  label: string;
+  description?: string;
+}
+
+export interface SettingFieldMeta {
+  label: string;
+  description?: string;
+  control?: 'toggle' | 'select' | 'number' | 'text';
+  valueType?: SettingValueType;
+  options?: readonly SettingFieldOption[] | SettingFieldOption[];
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  group?: string;
+}
+
+export interface SettingsFileMeta {
+  title?: string;
+  fields: Record<string, SettingFieldMeta>;
+  order?: string[];
+  groupOrder?: string[];
+}
+
+export const CAMERA_TYPE_OPTIONS = [
+  { value: 0, label: 'Dummy' },
+  { value: 2, label: 'External' },
+  { value: 3, label: 'External IP' },
+  { value: 4, label: 'Development file source' },
+  { value: 10, label: 'USB camera (software encode)' },
+  { value: 11, label: 'InfiRay thermal' },
+  { value: 12, label: 'InfiRay T2' },
+  { value: 13, label: 'InfiRay X2' },
+  { value: 14, label: 'InfiRay P2 Pro' },
+  { value: 15, label: 'FLIR Vue' },
+  { value: 16, label: 'FLIR Boson' },
+  { value: 20, label: 'Raspberry Pi HDMI to CSI' },
+  { value: 30, label: 'Raspberry Pi cam v1 (OV5647)' },
+  { value: 31, label: 'Raspberry Pi cam v2 (IMX219)' },
+  { value: 32, label: 'Raspberry Pi cam v3 (IMX708)' },
+  { value: 33, label: 'Raspberry Pi HQ (IMX477)' },
+  { value: 40, label: 'ArduCam Skymaster HDR' },
+  { value: 41, label: 'ArduCam Skyvision Pro' },
+  { value: 42, label: 'ArduCam IMX477M' },
+  { value: 43, label: 'ArduCam IMX462' },
+  { value: 44, label: 'ArduCam IMX327' },
+  { value: 45, label: 'ArduCam IMX290' },
+  { value: 46, label: 'ArduCam IMX462 Low-Light Mini' },
+  { value: 60, label: 'VEYE 2MP' },
+  { value: 61, label: 'VEYE IMX307' },
+  { value: 62, label: 'VEYE CSSC132' },
+  { value: 63, label: 'VEYE MVCAM' },
+  { value: 70, label: 'HDZero generic (X20)' },
+  { value: 71, label: 'HDZero RunCam V1 (X20)' },
+  { value: 72, label: 'HDZero RunCam V2 (X20)' },
+  { value: 73, label: 'HDZero RunCam V3 (X20)' },
+  { value: 74, label: 'HDZero RunCam Nano 90 (X20)' },
+  { value: 75, label: 'OHD Jaguar (X20)' },
+  { value: 76, label: 'OHD Jaguar (X21)' },
+  { value: 80, label: 'Rock 5 HDMI input' },
+  { value: 81, label: 'Rock 5 OV5647' },
+  { value: 82, label: 'Rock 5 IMX219' },
+  { value: 83, label: 'Rock 5 IMX708' },
+  { value: 84, label: 'Rock 5 IMX462' },
+  { value: 85, label: 'Rock 5 IMX415' },
+  { value: 86, label: 'Rock 5 IMX477' },
+  { value: 87, label: 'Rock 5 IMX519' },
+  { value: 88, label: 'Rock 5 OHD Jaguar' },
+  { value: 90, label: 'Rock 3 HDMI input' },
+  { value: 91, label: 'Rock 3 OV5647' },
+  { value: 92, label: 'Rock 3 IMX219' },
+  { value: 93, label: 'Rock 3 IMX708' },
+  { value: 94, label: 'Rock 3 IMX462' },
+  { value: 95, label: 'Rock 3 IMX519' },
+  { value: 96, label: 'Rock 3 OHD Jaguar' },
+  { value: 97, label: 'Rock 3 VEYE' },
+  { value: 101, label: 'NVIDIA Xavier IMX577' },
+  { value: 110, label: 'OpenIPC generic' },
+  { value: 120, label: 'Coretronic IMX577' },
+  { value: 121, label: 'Coretronic OV9282' },
+  { value: 122, label: 'Willy Hornet' },
+  { value: 123, label: 'Willy Jaguar' },
+  { value: 124, label: 'Willy Rekindle' },
+  { value: 255, label: 'Disabled' }
+] as const;
+
+const UART_BAUD_OPTIONS: readonly SettingFieldOption[] = [
+  9600,
+  19200,
+  38400,
+  57600,
+  115200,
+  230400,
+  460800,
+  500000,
+  576000,
+  921600,
+  1000000
+].map(value => ({ value, label: `${value.toLocaleString()} baud` }));
+
+const WIFI_HOTSPOT_OPTIONS: readonly SettingFieldOption[] = [
+  { value: 0, label: 'Automatic (disable when armed)' },
+  { value: 1, label: 'Always off' },
+  { value: 2, label: 'Always on' }
+];
+
+const ETHERNET_MODE_OPTIONS: readonly SettingFieldOption[] = [
+  { value: 0, label: 'Leave ethernet untouched' },
+  { value: 1, label: 'Hotspot mode (static IP)' },
+  { value: 2, label: 'Forward to external uplink' }
+];
+
+const BOOLEAN_SELECT_OPTIONS: readonly SettingFieldOption[] = [
+  { value: 0, label: 'Disabled' },
+  { value: 1, label: 'Enabled' }
+];
+
+export const SETTINGS_METADATA: Record<string, SettingsFileMeta> = {
+  'interface/networking_settings.json': {
+    title: 'Networking',
+    groupOrder: ['Interfaces'],
+    order: ['wifi_hotspot_mode', 'ethernet_operating_mode'],
+    fields: {
+      wifi_hotspot_mode: {
+        label: 'WiFi hotspot mode',
+        description: 'Control whether the OpenHD hotspot is managed automatically, forced off or always on.',
+        control: 'select',
+        valueType: 'number',
+        options: WIFI_HOTSPOT_OPTIONS,
+        group: 'Interfaces'
+      },
+      ethernet_operating_mode: {
+        label: 'Ethernet operating mode',
+        description: 'Choose how OpenHD configures the ethernet port (untouched, hotspot or forwarding).',
+        control: 'select',
+        valueType: 'number',
+        options: ETHERNET_MODE_OPTIONS,
+        group: 'Interfaces'
+      }
+    }
+  },
+  'telemetry/air_settings.json': {
+    title: 'Telemetry (air unit)',
+    groupOrder: ['Flight controller UART', 'Battery'],
+    order: ['fc_uart_connection_type', 'fc_uart_baudrate', 'fc_uart_flow_control', 'fc_battery_n_cells'],
+    fields: {
+      fc_uart_connection_type: {
+        label: 'Flight controller UART port',
+        description: 'Select which serial device OpenHD should use to communicate with the flight controller. "DEFAULT" resolves to the recommended port for the current platform.',
+        control: 'select',
+        valueType: 'string',
+        options: [
+          { value: 'DEFAULT', label: 'Auto-detect (platform default)' },
+          { value: '', label: 'Disabled' },
+          { value: '/dev/serial0', label: 'Raspberry Pi /dev/serial0' },
+          { value: '/dev/serial1', label: 'Raspberry Pi /dev/serial1' },
+          { value: '/dev/ttyUSB0', label: 'USB adapter /dev/ttyUSB0' },
+          { value: '/dev/ttyUSB1', label: 'USB adapter /dev/ttyUSB1' },
+          { value: '/dev/ttyACM0', label: 'USB flight controller /dev/ttyACM0' },
+          { value: '/dev/ttyACM1', label: 'USB flight controller /dev/ttyACM1' },
+          { value: '/dev/ttyS7', label: 'Rock 5B /dev/ttyS7' },
+          { value: '/dev/ttyS2', label: 'Rock /dev/ttyS2' }
+        ],
+        group: 'Flight controller UART'
+      },
+      fc_uart_baudrate: {
+        label: 'UART baud rate',
+        description: 'Allowed values follow the Linux serial driver (9 600 – 1 000 000 baud).',
+        control: 'select',
+        valueType: 'number',
+        options: UART_BAUD_OPTIONS,
+        group: 'Flight controller UART'
+      },
+      fc_uart_flow_control: {
+        label: 'Hardware flow control (RTS/CTS)',
+        description: 'Enable RTS/CTS flow control for flight-controller serial links that support it.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Flight controller UART'
+      },
+      fc_battery_n_cells: {
+        label: 'Battery cell count',
+        description: 'Set the number of cells reported by the flight controller (0 leaves it unset).',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 12,
+        group: 'Battery'
+      }
+    }
+  },
+  'video/air_camera_generic.json': {
+    title: 'Air video',
+    groupOrder: ['Cameras', 'Dual camera', 'Audio'],
+    order: [
+      'primary_camera_type',
+      'secondary_camera_type',
+      'switch_primary_and_secondary',
+      'dualcam_primary_video_allocated_bandwidth_perc',
+      'enable_audio'
+    ],
+    fields: {
+      primary_camera_type: {
+        label: 'Primary camera type',
+        description: 'Matches the camera enumeration used by OpenHD (camera.hpp).',
+        control: 'select',
+        valueType: 'number',
+        options: CAMERA_TYPE_OPTIONS,
+        group: 'Cameras'
+      },
+      secondary_camera_type: {
+        label: 'Secondary camera type',
+        description: 'Set to "Disabled" to keep the secondary stream inactive.',
+        control: 'select',
+        valueType: 'number',
+        options: CAMERA_TYPE_OPTIONS,
+        group: 'Cameras'
+      },
+      switch_primary_and_secondary: {
+        label: 'Swap primary and secondary inputs',
+        description: 'Swap detected camera order when the hardware enumeration is inverted.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Cameras'
+      },
+      dualcam_primary_video_allocated_bandwidth_perc: {
+        label: 'Primary camera bandwidth share (%)',
+        description: 'Allocate bitrate between primary and secondary streams (10% – 90%).',
+        control: 'number',
+        valueType: 'number',
+        min: 10,
+        max: 90,
+        step: 5,
+        group: 'Dual camera',
+        unit: '%'
+      },
+      enable_audio: {
+        label: 'Audio capture mode',
+        description: 'Enable real audio capture or run the encoder test tone.',
+        control: 'select',
+        valueType: 'number',
+        options: [
+          { value: 1, label: 'Disabled' },
+          { value: 0, label: 'Capture live audio' },
+          { value: 100, label: 'Enable test tone output' }
+        ],
+        group: 'Audio'
+      }
+    }
+  },
+  'interface/wifibroadcast_settings.json': {
+    title: 'WiFi broadcast link',
+    groupOrder: ['Radio link', 'Transmission power', 'FEC & encoding', 'RC integration', 'Advanced'],
+    order: [
+      'wb_frequency',
+      'wb_air_tx_channel_width',
+      'wb_air_mcs_index',
+      'wb_enable_stbc',
+      'wb_enable_ldpc',
+      'wb_enable_short_guard',
+      'enable_wb_video_variable_bitrate',
+      'wb_tx_power_milli_watt',
+      'wb_tx_power_milli_watt_armed',
+      'wb_rtl8812au_tx_pwr_idx_override',
+      'wb_rtl8812au_tx_pwr_idx_override_armed',
+      'wb_video_fec_percentage',
+      'wb_video_rate_for_mcs_adjustment_percent',
+      'wb_max_fec_block_size',
+      'wb_qp_min',
+      'wb_qp_max',
+      'wb_mcs_index_via_rc_channel',
+      'wb_bw_via_rc_channel',
+      'wb_enable_listen_only_mode',
+      'wb_dev_air_set_high_retransmit_count'
+    ],
+    fields: {
+      wb_frequency: {
+        label: 'Center frequency (MHz)',
+        description: 'Must be a supported WiFi channel frequency. OpenHD validates against the card capabilities.',
+        control: 'number',
+        valueType: 'number',
+        min: 2300,
+        max: 5900,
+        step: 1,
+        unit: 'MHz',
+        group: 'Radio link'
+      },
+      wb_air_tx_channel_width: {
+        label: 'Channel width (MHz)',
+        description: 'Valid channel widths are 10, 20 or 40 MHz.',
+        control: 'select',
+        valueType: 'number',
+        options: [
+          { value: 10, label: '10 MHz' },
+          { value: 20, label: '20 MHz' },
+          { value: 40, label: '40 MHz' }
+        ],
+        group: 'Radio link'
+      },
+      wb_air_mcs_index: {
+        label: 'Air unit MCS index',
+        description: '0 – 31 per validate_settings_helper.h; lower values trade throughput for range.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 31,
+        group: 'Radio link'
+      },
+      wb_enable_stbc: {
+        label: 'Enable STBC',
+        description: 'Space-time block coding can improve diversity on multi-antenna hardware.',
+        control: 'select',
+        valueType: 'number',
+        options: BOOLEAN_SELECT_OPTIONS,
+        group: 'Radio link'
+      },
+      wb_enable_ldpc: {
+        label: 'Enable LDPC',
+        description: 'Turn on low-density parity-check coding when supported by your radios.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Radio link'
+      },
+      wb_enable_short_guard: {
+        label: 'Use short guard interval',
+        description: 'Short guard intervals slightly reduce robustness but increase throughput.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Radio link'
+      },
+      enable_wb_video_variable_bitrate: {
+        label: 'Allow variable encoder bitrate',
+        description: 'Let the link dynamically request lower encoder bitrates on poor links.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Radio link'
+      },
+      wb_tx_power_milli_watt: {
+        label: 'TX power (mW)',
+        description: 'Valid range 10 – 30 000 mW per validate_settings_helper.h.',
+        control: 'number',
+        valueType: 'number',
+        min: 10,
+        max: 30000,
+        group: 'Transmission power',
+        unit: 'mW'
+      },
+      wb_tx_power_milli_watt_armed: {
+        label: 'TX power when armed (mW)',
+        description: 'Override transmit power when the vehicle is armed (0 keeps the default).',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 30000,
+        group: 'Transmission power',
+        unit: 'mW'
+      },
+      wb_rtl8812au_tx_pwr_idx_override: {
+        label: 'RTL8812AU TX power index',
+        description: 'Valid range 0 – 63.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 63,
+        group: 'Transmission power'
+      },
+      wb_rtl8812au_tx_pwr_idx_override_armed: {
+        label: 'RTL8812AU TX power index when armed',
+        description: 'Set to 0 to keep the default armed power index.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 63,
+        group: 'Transmission power'
+      },
+      wb_video_fec_percentage: {
+        label: 'Video FEC percentage',
+        description: 'Forward-error correction ratio (1 – 400%).',
+        control: 'number',
+        valueType: 'number',
+        min: 1,
+        max: 400,
+        step: 5,
+        group: 'FEC & encoding',
+        unit: '%'
+      },
+      wb_video_rate_for_mcs_adjustment_percent: {
+        label: 'Rate reduction for MCS (%)',
+        description: 'Reduce encoder bitrate relative to theoretical maximum (10 – 200%).',
+        control: 'number',
+        valueType: 'number',
+        min: 10,
+        max: 200,
+        step: 5,
+        group: 'FEC & encoding',
+        unit: '%'
+      },
+      wb_max_fec_block_size: {
+        label: 'Max FEC block size',
+        description: '0 enables automatic sizing, positive values clamp the block size. -1 keeps the platform default.',
+        control: 'number',
+        valueType: 'number',
+        min: -1,
+        max: 99,
+        group: 'FEC & encoding'
+      },
+      wb_qp_min: {
+        label: 'Encoder QP minimum',
+        description: 'Lower values improve quality but need more bandwidth (typical range 10 – 45).',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 51,
+        group: 'FEC & encoding'
+      },
+      wb_qp_max: {
+        label: 'Encoder QP maximum',
+        description: 'Higher values allow more compression at the cost of quality.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 51,
+        group: 'FEC & encoding'
+      },
+      wb_mcs_index_via_rc_channel: {
+        label: 'RC channel for MCS control',
+        description: '0 disables RC control. Otherwise set the RC channel index that should modify MCS.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 16,
+        group: 'RC integration'
+      },
+      wb_bw_via_rc_channel: {
+        label: 'RC channel for bandwidth control',
+        description: '0 disables RC control. Otherwise choose the RC channel used for bandwidth switching.',
+        control: 'number',
+        valueType: 'number',
+        min: 0,
+        max: 16,
+        group: 'RC integration'
+      },
+      wb_enable_listen_only_mode: {
+        label: 'Listen-only mode',
+        description: 'Enable passive reception without transmitting (developer/diagnostic use).',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Advanced'
+      },
+      wb_dev_air_set_high_retransmit_count: {
+        label: 'High retransmit count (developer)',
+        description: 'Developer option to raise WiFi retransmit thresholds.',
+        control: 'toggle',
+        valueType: 'boolean',
+        group: 'Advanced'
+      }
+    }
+  }
+};

--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -385,6 +385,231 @@ td {
   min-width: 0;
 }
 
+.structured-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+:host-context(.dark-theme) .structured-editor {
+  background: rgba(21, 30, 39, 0.85);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.structured-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.structured-group h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+:host-context(.dark-theme) .structured-group h5 {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.structured-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.structured-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+:host-context(.dark-theme) .structured-field {
+  background: rgba(30, 41, 59, 0.9);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.structured-field.toggle-field {
+  align-items: flex-start;
+}
+
+.field-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.field-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field-unit {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+:host-context(.dark-theme) .field-unit {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.field-description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+:host-context(.dark-theme) .field-description {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.field-tag {
+  align-self: flex-start;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  background: rgba(0, 166, 242, 0.12);
+  color: #0377bd;
+}
+
+:host-context(.dark-theme) .field-tag {
+  background: rgba(255, 255, 255, 0.12);
+  color: #8fd1ff;
+}
+
+.field-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.structured-input {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  border-radius: 6px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: rgba(255, 255, 255, 0.95);
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+:host-context(.dark-theme) .structured-input {
+  background: rgba(21, 30, 39, 0.9);
+  border-color: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.structured-toggle {
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.structured-toggle span {
+  font-weight: 600;
+}
+
+.structured-unknown {
+  margin-top: 0.5rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(15, 23, 42, 0.18);
+  background: rgba(15, 23, 42, 0.02);
+}
+
+:host-context(.dark-theme) .structured-unknown {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.structured-unknown h5 {
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
+}
+
+.structured-unknown p {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+:host-context(.dark-theme) .structured-unknown p {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.structured-unknown ul {
+  margin: 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.structured-unknown code {
+  background: rgba(15, 23, 42, 0.08);
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.75rem;
+}
+
+:host-context(.dark-theme) .structured-unknown code {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.raw-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.raw-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.raw-header h5 {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+:host-context(.dark-theme) .raw-header h5 {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.raw-hint {
+  font-size: 0.75rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+:host-context(.dark-theme) .raw-hint {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.raw-error {
+  color: #d9534f;
+  font-size: 0.8rem;
+}
+
+:host-context(.dark-theme) .raw-error {
+  color: #ff6b6b;
+}
+
 .settings-editor.placeholder {
   justify-content: center;
   align-items: center;

--- a/src/openhdwebui.client/src/app/settings/settings.component.html
+++ b/src/openhdwebui.client/src/app/settings/settings.component.html
@@ -119,7 +119,75 @@
             <span class="error" *ngIf="fileError">{{ fileError }}</span>
           </div>
         </div>
-        <textarea [(ngModel)]="selectedSetting.content" [disabled]="isLoadingFile || isSavingFile"></textarea>
+
+        <div class="structured-editor" *ngIf="hasStructuredView">
+          <div class="structured-group" *ngFor="let group of structuredGroups">
+            <h5 *ngIf="group.title">{{ group.title }}</h5>
+            <div class="structured-grid">
+              <div class="structured-field" *ngFor="let field of group.fields" [class.toggle-field]="field.control === 'toggle'">
+                <div class="field-header">
+                  <div class="field-title">{{ field.label }}</div>
+                  <span class="field-unit" *ngIf="field.unit">{{ field.unit }}</span>
+                </div>
+                <p class="field-description" *ngIf="field.description">{{ field.description }}</p>
+                <span class="field-tag" *ngIf="!field.hasMetadata">Generic control</span>
+                <div class="field-control" [ngSwitch]="field.control">
+                  <label class="toggle structured-toggle" *ngSwitchCase="'toggle'">
+                    <input type="checkbox" [checked]="field.value as boolean"
+                           (change)="onFieldChange(field, $event.target?.checked)"
+                           [disabled]="isLoadingFile || isSavingFile">
+                    <span>{{ field.value ? 'Enabled' : 'Disabled' }}</span>
+                  </label>
+                  <select *ngSwitchCase="'select'" class="structured-input"
+                          [ngModel]="field.value"
+                          (ngModelChange)="onFieldChange(field, $event)"
+                          [ngModelOptions]="{ standalone: true }"
+                          [disabled]="isLoadingFile || isSavingFile">
+                    <option *ngFor="let option of field.options" [ngValue]="option.value">
+                      {{ option.label }}
+                    </option>
+                  </select>
+                  <input *ngSwitchCase="'number'" type="number" class="structured-input"
+                         [ngModel]="field.value"
+                         (ngModelChange)="onFieldChange(field, $event)"
+                         [ngModelOptions]="{ standalone: true }"
+                         [attr.min]="field.min"
+                         [attr.max]="field.max"
+                         [attr.step]="field.step"
+                         [disabled]="isLoadingFile || isSavingFile">
+                  <input *ngSwitchDefault type="text" class="structured-input"
+                         [ngModel]="field.value"
+                         (ngModelChange)="onFieldChange(field, $event)"
+                         [ngModelOptions]="{ standalone: true }"
+                         [disabled]="isLoadingFile || isSavingFile">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="structured-unknown" *ngIf="structuredUnknownEntries.length">
+          <h5>Other values</h5>
+          <p>These settings are available in the file but do not yet have a dedicated control.</p>
+          <ul>
+            <li *ngFor="let entry of structuredUnknownEntries">
+              <strong>{{ entry.key }}</strong>
+              <code>{{ entry.value | json }}</code>
+            </li>
+          </ul>
+        </div>
+
+        <div class="raw-editor">
+          <div class="raw-header">
+            <h5>Raw JSON</h5>
+            <span class="raw-hint">Advanced users can edit the JSON directly. Changes sync with the controls above.</span>
+          </div>
+          <textarea [ngModel]="rawContent"
+                    (ngModelChange)="onRawContentChange($event)"
+                    [disabled]="isLoadingFile || isSavingFile"></textarea>
+          <div class="raw-error" *ngIf="rawParseError">{{ rawParseError }}</div>
+        </div>
+
         <div class="editor-actions">
           <button (click)="saveSelectedSetting()" [disabled]="isSavingFile">Save changes</button>
         </div>

--- a/src/openhdwebui.client/src/app/settings/settings.component.ts
+++ b/src/openhdwebui.client/src/app/settings/settings.component.ts
@@ -1,6 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { ThemeService } from '../theme.service';
+import {
+  SETTINGS_METADATA,
+  SettingFieldMeta,
+  SettingFieldOption,
+  SettingValueType,
+  SettingsFileMeta
+} from './settings-metadata';
 
 interface WifiInterface {
   name: string;
@@ -29,6 +36,27 @@ interface SettingFileDetail extends SettingFileSummary {
   content: string;
 }
 
+interface StructuredSettingField {
+  key: string;
+  label: string;
+  description?: string;
+  control: 'toggle' | 'select' | 'number' | 'text';
+  value: string | number | boolean;
+  valueType: SettingValueType;
+  options?: SettingFieldOption[];
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+  group?: string;
+  hasMetadata: boolean;
+}
+
+interface StructuredSettingGroup {
+  title?: string;
+  fields: StructuredSettingField[];
+}
+
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
@@ -44,6 +72,15 @@ export class SettingsComponent implements OnInit {
   isLoadingFile = false;
   isSavingFile = false;
   saveSuccess = false;
+
+  rawContent = '';
+  rawParseError?: string;
+  structuredGroups: StructuredSettingGroup[] = [];
+  structuredUnknownEntries: { key: string; value: unknown }[] = [];
+  hasStructuredView = false;
+
+  private selectedSettingData: Record<string, unknown> | null = null;
+  private suppressRawChange = false;
 
   constructor(public themeService: ThemeService, private http: HttpClient) {}
 
@@ -105,6 +142,7 @@ export class SettingsComponent implements OnInit {
       .subscribe({
       next: updated => {
         this.selectedSetting = updated;
+        this.buildStructuredEditor(updated);
         this.isSavingFile = false;
         this.saveSuccess = true;
         this.updateSummary(updated);
@@ -165,6 +203,7 @@ export class SettingsComponent implements OnInit {
       next: file => {
         this.selectedSetting = file;
         this.isLoadingFile = false;
+        this.buildStructuredEditor(file);
       },
       error: err => {
         this.isLoadingFile = false;
@@ -179,5 +218,278 @@ export class SettingsComponent implements OnInit {
     if (index >= 0) {
       this.settingFiles[index] = { ...updated };
     }
+  }
+
+  onFieldChange(field: StructuredSettingField, newValue: any): void {
+    const value = this.castValue(newValue, field.valueType, field);
+    if (value === undefined) {
+      return;
+    }
+
+    field.value = value;
+    if (this.selectedSettingData) {
+      this.selectedSettingData[field.key] = value;
+      this.syncRawContentFromStructured();
+    }
+  }
+
+  onRawContentChange(content: string): void {
+    this.rawContent = content;
+    if (this.selectedSetting) {
+      this.selectedSetting.content = content;
+    }
+
+    if (this.suppressRawChange) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(content);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        this.selectedSettingData = null;
+        this.structuredGroups = [];
+        this.structuredUnknownEntries = [];
+        this.hasStructuredView = false;
+        this.rawParseError = undefined;
+        return;
+      }
+      this.rawParseError = undefined;
+      this.selectedSettingData = parsed as Record<string, unknown>;
+      const file = this.selectedSetting;
+      if (file) {
+        this.populateStructuredView(parsed as Record<string, unknown>, file);
+      }
+    } catch (err) {
+      this.structuredGroups = [];
+      this.structuredUnknownEntries = [];
+      this.hasStructuredView = false;
+      this.rawParseError = 'The JSON content contains syntax errors. Fix the file to re-enable the interactive editor.';
+    }
+  }
+
+  private buildStructuredEditor(file: SettingFileDetail): void {
+    this.rawContent = file.content;
+    this.rawParseError = undefined;
+    this.structuredGroups = [];
+    this.structuredUnknownEntries = [];
+    this.hasStructuredView = false;
+
+    try {
+      const parsed = JSON.parse(file.content);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        this.selectedSettingData = null;
+        return;
+      }
+      this.selectedSettingData = parsed as Record<string, unknown>;
+      this.populateStructuredView(parsed as Record<string, unknown>, file);
+    } catch (err) {
+      this.selectedSettingData = null;
+      this.rawParseError = 'Unable to parse this settings file as JSON.';
+    }
+  }
+
+  private populateStructuredView(data: Record<string, unknown>, file: SettingFileDetail): void {
+    const meta = this.resolveMetadata(file);
+    const fields: StructuredSettingField[] = [];
+    const unknown: { key: string; value: unknown }[] = [];
+
+    const orderedEntries = Object.entries(data);
+    for (const [key, value] of orderedEntries) {
+      const field = this.createFieldDescriptor(key, value, meta?.fields[key]);
+      if (field) {
+        fields.push(field);
+      } else {
+        unknown.push({ key, value });
+      }
+    }
+
+    const sortedFields = this.sortFields(fields, meta);
+    this.structuredGroups = this.groupFields(sortedFields, meta);
+    this.structuredUnknownEntries = unknown;
+    this.hasStructuredView = this.structuredGroups.some(group => group.fields.length > 0);
+  }
+
+  private resolveMetadata(file: SettingFileSummary): SettingsFileMeta | undefined {
+    const normalized = file.relativePath?.replace(/\\/g, '/').toLowerCase();
+    if (!normalized) {
+      return undefined;
+    }
+    if (SETTINGS_METADATA[normalized]) {
+      return SETTINGS_METADATA[normalized];
+    }
+    const match = Object.entries(SETTINGS_METADATA).find(([key]) => normalized.endsWith(key));
+    return match?.[1];
+  }
+
+  private createFieldDescriptor(key: string, value: unknown, meta?: SettingFieldMeta): StructuredSettingField | undefined {
+    if (value === null || typeof value === 'object') {
+      return undefined;
+    }
+
+    const valueType: SettingValueType = meta?.valueType ?? this.detectValueType(value);
+    if (!valueType) {
+      return undefined;
+    }
+
+    const label = meta?.label ?? this.toTitleCase(key.replace(/_/g, ' '));
+    const control = this.resolveControl(meta, valueType);
+    const options = meta?.options ? [...meta.options] : undefined;
+    const coercedValue = this.castValue(value, valueType, meta);
+    if (coercedValue === undefined) {
+      return undefined;
+    }
+
+    return {
+      key,
+      label,
+      description: meta?.description,
+      control,
+      value: coercedValue,
+      valueType,
+      options,
+      min: meta?.min,
+      max: meta?.max,
+      step: meta?.step,
+      unit: meta?.unit,
+      group: meta?.group,
+      hasMetadata: !!meta
+    };
+  }
+
+  private sortFields(fields: StructuredSettingField[], meta?: SettingsFileMeta): StructuredSettingField[] {
+    if (!meta?.order || meta.order.length === 0) {
+      return [...fields].sort((a, b) => a.label.localeCompare(b.label));
+    }
+
+    const order = meta.order;
+    const indexFor = (key: string): number => {
+      const idx = order.indexOf(key);
+      return idx === -1 ? Number.MAX_SAFE_INTEGER : idx;
+    };
+
+    return [...fields].sort((a, b) => {
+      const aIndex = indexFor(a.key);
+      const bIndex = indexFor(b.key);
+      if (aIndex !== bIndex) {
+        return aIndex - bIndex;
+      }
+      return a.label.localeCompare(b.label);
+    });
+  }
+
+  private groupFields(fields: StructuredSettingField[], meta?: SettingsFileMeta): StructuredSettingGroup[] {
+    const buckets = new Map<string, StructuredSettingField[]>();
+    for (const field of fields) {
+      const key = field.group ?? '';
+      if (!buckets.has(key)) {
+        buckets.set(key, []);
+      }
+      buckets.get(key)!.push(field);
+    }
+
+    const groupOrder = meta?.groupOrder ?? [];
+    const orderedKeys: string[] = [];
+    for (const entry of groupOrder) {
+      if (buckets.has(entry)) {
+        orderedKeys.push(entry);
+      }
+    }
+    for (const key of buckets.keys()) {
+      if (!orderedKeys.includes(key)) {
+        orderedKeys.push(key);
+      }
+    }
+
+    return orderedKeys.map(key => ({
+      title: key || undefined,
+      fields: buckets.get(key) ?? []
+    })).filter(group => group.fields.length > 0);
+  }
+
+  private detectValueType(value: unknown): SettingValueType {
+    switch (typeof value) {
+      case 'boolean':
+        return 'boolean';
+      case 'number':
+        return 'number';
+      default:
+        return 'string';
+    }
+  }
+
+  private resolveControl(meta: SettingFieldMeta | undefined, valueType: SettingValueType): StructuredSettingField['control'] {
+    if (meta?.control) {
+      return meta.control;
+    }
+    if (meta?.options && meta.options.length > 0) {
+      return 'select';
+    }
+    if (valueType === 'boolean') {
+      return 'toggle';
+    }
+    if (valueType === 'number') {
+      return 'number';
+    }
+    return 'text';
+  }
+
+  private castValue(
+    value: any,
+    valueType: SettingValueType,
+    meta?: { min?: number; max?: number }
+  ): string | number | boolean | undefined {
+    if (valueType === 'boolean') {
+      if (typeof value === 'string') {
+        return value === 'true' || value === '1';
+      }
+      if (typeof value === 'number') {
+        return value !== 0;
+      }
+      return Boolean(value);
+    }
+
+    if (valueType === 'number') {
+      const numeric = typeof value === 'number' ? value : Number(value);
+      if (Number.isNaN(numeric)) {
+        return undefined;
+      }
+      let constrained = numeric;
+      if (meta?.min !== undefined && constrained < meta.min) {
+        constrained = meta.min;
+      }
+      if (meta?.max !== undefined && constrained > meta.max) {
+        constrained = meta.max;
+      }
+      return constrained;
+    }
+
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return String(value);
+  }
+
+  private syncRawContentFromStructured(): void {
+    if (!this.selectedSetting || !this.selectedSettingData) {
+      return;
+    }
+    this.suppressRawChange = true;
+    const formatted = JSON.stringify(this.selectedSettingData, null, 2);
+    this.rawContent = formatted;
+    this.selectedSetting.content = formatted;
+    setTimeout(() => {
+      this.suppressRawChange = false;
+    });
+  }
+
+  private toTitleCase(text: string): string {
+    return text
+      .split(' ')
+      .filter(part => part.length > 0)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
   }
 }


### PR DESCRIPTION
## Summary
- introduce a metadata map for OpenHD settings to describe labels, ranges, and options for known files
- enhance the Angular settings component to render structured controls, keep the raw JSON editor in sync, and surface unmapped values
- style the structured editor with responsive layout, helper text, and raw-editor messaging

## Testing
- npm run lint -- --no-fix *(fails: script "lint" is not defined)*
- npm run build *(fails: ng CLI is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dfdaf538832f96b753800e0a11e9