### PR TITLE
Ensure PATH is preserved when building docs

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -186,7 +186,8 @@ partial class Build : NukeBuild
 
         var environmentVariables = new Dictionary<string, string>
         {
-            ["BASE_URL"] = DocsBaseUrl
+            ["BASE_URL"] = DocsBaseUrl,
+            ["PATH"] = Environment.GetEnvironmentVariable("PATH") ?? string.Empty
         };
 
         ProcessTasks.StartProcess("npm", "run build", workingDirectory: DocsClonePath.ToString(), environmentVariables: environmentVariables)


### PR DESCRIPTION
## Summary
- include the existing PATH when invoking the documentation build so npm can find node

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d707419cd8832f9ef2ccebe6bc82a8