### PR TITLE
Adjust docs retrieval for build

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: 'Clone documentation repository'
+        run: git clone --depth 1 https://github.com/OpenHD/OpenHD-Website.git OpenHD-Website
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v4
         with:
@@ -40,6 +42,7 @@ jobs:
           ./build.cmd Clean CloudsmithPublish 2>&1 | tee build.log
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          DOCS_REPOSITORY_PATH: ${{ github.workspace }}/OpenHD-Website
       - name: 'Upload build log'
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- clone the OpenHD-Website repository in the CI workflow before executing the build
- update the build script to consume a pre-cloned documentation repository instead of cloning it internally

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71423e20c832fb1ab071e9f3b7623