### PR TITLE
Ensure settings text stays readable in dark mode

### DIFF
--- a/src/openhdwebui.client/src/app/settings/settings.component.css
+++ b/src/openhdwebui.client/src/app/settings/settings.component.css
@@ -43,6 +43,10 @@
   font-weight: 600;
 }
 
+:host-context(.dark-theme) .toggle {
+  color: #fff;
+}
+
 .toggle input {
   width: 1.2rem;
   height: 1.2rem;
@@ -375,6 +379,10 @@ td {
   font-weight: 600;
 }
 
+:host-context(.dark-theme) .file-name {
+  color: #fff;
+}
+
 .file-path {
   font-size: 0.8rem;
   color: rgba(15, 23, 42, 0.6);
@@ -470,6 +478,10 @@ td {
 .field-title {
   font-weight: 600;
   font-size: 0.95rem;
+}
+
+:host-context(.dark-theme) .field-title {
+  color: #fff;
 }
 
 .field-unit {


### PR DESCRIPTION
## Summary
- ensure toggle labels inherit a white color in dark theme
- make settings file name and field title text white on dark backgrounds for readability

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8048769c4832f97ae5a6ee2398532